### PR TITLE
Update to version v1.9.0

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v1.8.0"
+	Version = "v1.9.0"
 )


### PR DESCRIPTION
Update release version to v1.9.0 to reflect change from `workos-inc` to `workos`