### PR TITLE
Update Go to 1.17

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,9 +12,7 @@ blocks:
         - name: gofmt
           commands:
             - checkout
-            - sem-version go 1.14
-            - yes | sudo apt update
-            - yes | sudo apt install gccgo-go
+            - sem-version go 1.17.5
             - diff -u <(echo -n) <(gofmt -d ./)
 
   - name: Run tests
@@ -28,7 +26,7 @@ blocks:
         - name: go test
           commands:
             - checkout
-            - sem-version go 1.14
+            - sem-version go 1.17.5
             - go get github.com/stretchr/testify
             - go get github.com/google/go-querystring
             - go get github.com/google/uuid

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -34,8 +34,8 @@ func TestGetOrganization(t *testing.T) {
 				Organization: "organization_id",
 			},
 			expected: Organization{
-				ID:   "organization_id",
-				Name: "Foo Corp",
+				ID:                               "organization_id",
+				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
@@ -75,8 +75,8 @@ func getOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(Organization{
-		ID:   "organization_id",
-		Name: "Foo Corp",
+		ID:                               "organization_id",
+		Name:                             "Foo Corp",
 		AllowProfilesOutsideOrganization: false,
 		Domains: []OrganizationDomain{
 			OrganizationDomain{
@@ -119,8 +119,8 @@ func TestListOrganizations(t *testing.T) {
 			expected: ListOrganizationsResponse{
 				Data: []Organization{
 					Organization{
-						ID:   "organization_id",
-						Name: "Foo Corp",
+						ID:                               "organization_id",
+						Name:                             "Foo Corp",
 						AllowProfilesOutsideOrganization: false,
 						Domains: []OrganizationDomain{
 							OrganizationDomain{
@@ -176,8 +176,8 @@ func listOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
 		ListOrganizationsResponse: ListOrganizationsResponse{
 			Data: []Organization{
 				Organization{
-					ID:   "organization_id",
-					Name: "Foo Corp",
+					ID:                               "organization_id",
+					Name:                             "Foo Corp",
 					AllowProfilesOutsideOrganization: false,
 					Domains: []OrganizationDomain{
 						OrganizationDomain{
@@ -225,8 +225,8 @@ func TestCreateOrganization(t *testing.T) {
 				Domains: []string{"foo-corp.com"},
 			},
 			expected: Organization{
-				ID:   "organization_id",
-				Name: "Foo Corp",
+				ID:                               "organization_id",
+				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
@@ -292,8 +292,8 @@ func createOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := json.Marshal(
 		Organization{
-			ID:   "organization_id",
-			Name: "Foo Corp",
+			ID:                               "organization_id",
+			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{
@@ -336,8 +336,8 @@ func TestUpdateOrganization(t *testing.T) {
 				Domains:      []string{"foo-corp.com", "foo-corp.io"},
 			},
 			expected: Organization{
-				ID:   "organization_id",
-				Name: "Foo Corp",
+				ID:                               "organization_id",
+				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
@@ -408,8 +408,8 @@ func updateOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := json.Marshal(
 		Organization{
-			ID:   "organization_id",
-			Name: "Foo Corp",
+			ID:                               "organization_id",
+			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -21,8 +21,8 @@ func TestOrganizationsGetOrganization(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := Organization{
-		ID:   "organization_id",
-		Name: "Foo Corp",
+		ID:                               "organization_id",
+		Name:                             "Foo Corp",
 		AllowProfilesOutsideOrganization: false,
 		Domains: []OrganizationDomain{
 			OrganizationDomain{
@@ -52,8 +52,8 @@ func TestOrganizationsListOrganizations(t *testing.T) {
 	expectedResponse := ListOrganizationsResponse{
 		Data: []Organization{
 			Organization{
-				ID:   "organization_id",
-				Name: "Foo Corp",
+				ID:                               "organization_id",
+				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
 					OrganizationDomain{
@@ -89,8 +89,8 @@ func TestOrganizationsCreateOrganization(t *testing.T) {
 
 	expectedResponse :=
 		Organization{
-			ID:   "organization_id",
-			Name: "Foo Corp",
+			ID:                               "organization_id",
+			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{
@@ -121,8 +121,8 @@ func TestOrganizationsUpdateOrganization(t *testing.T) {
 
 	expectedResponse :=
 		Organization{
-			ID:   "organization_id",
-			Name: "Foo Corp",
+			ID:                               "organization_id",
+			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
 				OrganizationDomain{


### PR DESCRIPTION
Trying this separately from https://github.com/workos/workos-go/pull/144

Updates Go version to 1.17.5 in Semaphore and runs `gofmt`.