### PR TITLE
Test additional Go release versions

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,7 +12,7 @@ blocks:
         - name: gofmt
           commands:
             - checkout
-            - sem-version go 1.17.5
+            - sem-version go 1.18
             - diff -u <(echo -n) <(gofmt -d ./)
 
   - name: Run tests
@@ -23,10 +23,18 @@ blocks:
           - export "PATH=$(go env GOPATH)/bin:${PATH}"
           - mkdir -vp "${SEMAPHORE_GIT_DIR}" "$(go env GOPATH)/bin"
       jobs:
-        - name: go test
+        - name: go 1.18 test
           commands:
             - checkout
-            - sem-version go 1.17.5
+            - sem-version go 1.18
+            - go get github.com/stretchr/testify
+            - go get github.com/google/go-querystring
+            - go get github.com/google/uuid
+            - go test -v ./...
+        - name: go 1.13 test
+          commands:
+            - checkout
+            - sem-version go 1.13
             - go get github.com/stretchr/testify
             - go get github.com/google/go-querystring
             - go get github.com/google/uuid

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,18 +23,13 @@ blocks:
           - export "PATH=$(go env GOPATH)/bin:${PATH}"
           - mkdir -vp "${SEMAPHORE_GIT_DIR}" "$(go env GOPATH)/bin"
       jobs:
-        - name: go 1.18 test
+        - name: go test
+          matrix:
+            - env_var: GO_VERSION
+              values: ["1.13", "1.18"]
           commands:
             - checkout
-            - sem-version go 1.18
-            - go get github.com/stretchr/testify
-            - go get github.com/google/go-querystring
-            - go get github.com/google/uuid
-            - go test -v ./...
-        - name: go 1.13 test
-          commands:
-            - checkout
-            - sem-version go 1.13
+            - sem-version go $GO_VERSION
             - go get github.com/stretchr/testify
             - go get github.com/google/go-querystring
             - go get github.com/google/uuid


### PR DESCRIPTION
Resolves SDK-405.

Since Go 1.x releases are backwards compatible this might not be necessary, it'll definitely be needed if/when 2.x is released. With that said, it's not going to hurt anything to test an older version (1.3 from June 2014) and the latest version (1.8 March 2022).