### PR TITLE
Expose HTTPError struct

### DIFF
--- a/pkg/audittrail/client.go
+++ b/pkg/audittrail/client.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/workos/workos-go/pkg/workos_errors"
+
 	"github.com/google/go-querystring/query"
 
 	"github.com/workos/workos-go/internal/workos"
@@ -133,7 +135,7 @@ func (c *Client) Publish(ctx context.Context, e EventOpts) error {
 	}
 	defer res.Body.Close()
 
-	return workos.TryGetHTTPError(res)
+	return workos_errors.TryGetHTTPError(res)
 }
 
 // ListEventsOpts contains options to fetch Audit Trail events.
@@ -285,7 +287,7 @@ func (c *Client) ListEvents(ctx context.Context, opts ListEventsOpts) (ListEvent
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return ListEventsResponse{}, err
 	}
 

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/workos/workos-go/pkg/workos_errors"
+
 	"github.com/workos/workos-go/internal/workos"
 	"github.com/workos/workos-go/pkg/common"
 )
@@ -183,7 +185,7 @@ func (c *Client) ListUsers(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return ListUsersResponse{}, err
 	}
 
@@ -274,7 +276,7 @@ func (c *Client) ListGroups(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return ListGroupsResponse{}, err
 	}
 
@@ -322,7 +324,7 @@ func (c *Client) GetUser(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return User{}, err
 	}
 
@@ -370,7 +372,7 @@ func (c *Client) GetGroup(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return Group{}, err
 	}
 
@@ -511,7 +513,7 @@ func (c *Client) ListDirectories(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return ListDirectoriesResponse{}, err
 	}
 
@@ -559,7 +561,7 @@ func (c *Client) GetDirectory(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return Directory{}, err
 	}
 
@@ -607,5 +609,5 @@ func (c *Client) DeleteDirectory(
 	}
 	defer res.Body.Close()
 
-	return workos.TryGetHTTPError(res)
+	return workos_errors.TryGetHTTPError(res)
 }

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/workos/workos-go/pkg/workos_errors"
+
 	"github.com/workos/workos-go/internal/workos"
 )
 
@@ -192,7 +194,7 @@ func (c *Client) EnrollFactor(
 		return EnrollResponse{}, err
 	}
 
-	if err = workos.TryGetHTTPError(resp); err != nil {
+	if err = workos_errors.TryGetHTTPError(resp); err != nil {
 		return EnrollResponse{}, err
 	}
 
@@ -233,7 +235,7 @@ func (c *Client) ChallengeFactor(
 		return ChallengeResponse{}, err
 	}
 
-	if err = workos.TryGetHTTPError(resp); err != nil {
+	if err = workos_errors.TryGetHTTPError(resp); err != nil {
 		return ChallengeResponse{}, err
 	}
 

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/workos/workos-go/pkg/workos_errors"
+
 	"github.com/google/go-querystring/query"
 	"github.com/workos/workos-go/internal/workos"
 	"github.com/workos/workos-go/pkg/common"
@@ -172,7 +174,7 @@ func (c *Client) GetOrganization(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return Organization{}, err
 	}
 
@@ -221,7 +223,7 @@ func (c *Client) ListOrganizations(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return ListOrganizationsResponse{}, err
 	}
 
@@ -256,7 +258,7 @@ func (c *Client) CreateOrganization(ctx context.Context, opts CreateOrganization
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return Organization{}, err
 	}
 
@@ -306,7 +308,7 @@ func (c *Client) UpdateOrganization(ctx context.Context, opts UpdateOrganization
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return Organization{}, err
 	}
 
@@ -354,5 +356,5 @@ func (c *Client) DeleteOrganization(
 	}
 	defer res.Body.Close()
 
-	return workos.TryGetHTTPError(res)
+	return workos_errors.TryGetHTTPError(res)
 }

--- a/pkg/passwordless/client.go
+++ b/pkg/passwordless/client.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/workos/workos-go/pkg/workos_errors"
+
 	"github.com/workos/workos-go/internal/workos"
 )
 
@@ -126,7 +128,7 @@ func (c *Client) CreateSession(ctx context.Context, opts CreateSessionOpts) (Pas
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return PasswordlessSession{}, err
 	}
 
@@ -174,5 +176,5 @@ func (c *Client) SendSession(
 	}
 	defer res.Body.Close()
 
-	return workos.TryGetHTTPError(res)
+	return workos_errors.TryGetHTTPError(res)
 }

--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/workos/workos-go/pkg/workos_errors"
+
 	"github.com/workos/workos-go/internal/workos"
 )
 
@@ -102,7 +104,7 @@ func (c *Client) GenerateLink(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return "", err
 	}
 

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/workos/workos-go/pkg/workos_errors"
+
 	"github.com/workos/workos-go/internal/workos"
 	"github.com/workos/workos-go/pkg/common"
 )
@@ -252,7 +254,7 @@ func (c *Client) GetProfileAndToken(ctx context.Context, opts GetProfileAndToken
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return ProfileAndToken{}, err
 	}
 
@@ -293,7 +295,7 @@ func (c *Client) GetProfile(ctx context.Context, opts GetProfileOptions) (Profil
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return Profile{}, err
 	}
 
@@ -402,7 +404,7 @@ func (c *Client) GetConnection(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return Connection{}, err
 	}
 
@@ -486,7 +488,7 @@ func (c *Client) ListConnections(
 	}
 	defer res.Body.Close()
 
-	if err = workos.TryGetHTTPError(res); err != nil {
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
 		return ListConnectionsResponse{}, err
 	}
 
@@ -534,5 +536,5 @@ func (c *Client) DeleteConnection(
 	}
 	defer res.Body.Close()
 
-	return workos.TryGetHTTPError(res)
+	return workos_errors.TryGetHTTPError(res)
 }

--- a/pkg/workos_errors/errors.go
+++ b/pkg/workos_errors/errors.go
@@ -2,11 +2,10 @@ package workos_errors
 
 import (
 	"errors"
-	"github.com/workos/workos-go/internal/workos"
 	"net/http"
 )
 
 func IsBadRequest(err error) bool {
-	var httpError workos.HTTPError
+	var httpError HTTPError
 	return errors.As(err, &httpError) && httpError.Code == http.StatusBadRequest
 }

--- a/pkg/workos_errors/errors_test.go
+++ b/pkg/workos_errors/errors_test.go
@@ -2,10 +2,10 @@ package workos_errors_test
 
 import (
 	"fmt"
-	"github.com/workos/workos-go/internal/workos"
-	"github.com/workos/workos-go/pkg/workos_errors"
 	"net/http"
 	"testing"
+
+	"github.com/workos/workos-go/pkg/workos_errors"
 )
 
 func TestIsBadRequest(t *testing.T) {
@@ -19,14 +19,14 @@ func TestIsBadRequest(t *testing.T) {
 	}{
 		{
 			name: "bad request",
-			args: args{err: workos.HTTPError{
+			args: args{err: workos_errors.HTTPError{
 				Code: http.StatusBadRequest,
 			}},
 			want: true,
 		},
 		{
 			name: "internal server error",
-			args: args{err: workos.HTTPError{
+			args: args{err: workos_errors.HTTPError{
 				Code: http.StatusInternalServerError,
 			}},
 			want: false,

--- a/pkg/workos_errors/http.go
+++ b/pkg/workos_errors/http.go
@@ -1,4 +1,4 @@
-package workos
+package workos_errors
 
 import (
 	"encoding/json"

--- a/pkg/workos_errors/http_test.go
+++ b/pkg/workos_errors/http_test.go
@@ -1,4 +1,4 @@
-package workos
+package workos_errors
 
 import (
 	"net/http"


### PR DESCRIPTION
# Context

The HTTPError struct is part of the API response and as such should be exposed.
If it's hidden in an internal package, then error handling for WorkOS API users becomes a problem.

The only way to get the error code is to parse the error string, and that implementation is not ideal and could become invalid whenever the Error method changes.

Currently, there's only a public bad request checker in the workos_errors pkg. Many times, invalid requests have a different code than just 400 (we receive many 422, for example).

# Description

This PR moves the `HTTPError` struct definition, methods, helping functions and tests from the internal `workos` pkg to the public `workos_errors` pkg.

It also updates all their usages as well.

This PR would also close the following issue: https://github.com/workos/workos-go/issues/151