### PR TITLE
Update endpoints used for MFA operations

### DIFF
--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -245,6 +245,14 @@ func (c *Client) ChallengeFactor(
 
 }
 
+// Deprecated: Use VerifyChallenge instead.
+func (c *Client) VerifyFactor(
+	ctx context.Context,
+	opts VerifyOpts,
+) (interface{}, error) {
+	return VerifyChallenge(ctx, opts)
+}
+
 // Verifies the one time password provided by the end-user.
 func (c *Client) VerifyChallenge(
 	ctx context.Context,
@@ -262,7 +270,7 @@ func (c *Client) VerifyChallenge(
 	})
 	responseBody := bytes.NewBuffer(postBody)
 
-	endpoint := fmt.Sprintf("%s/auth/factors/verify", c.Endpoint)
+	endpoint := fmt.Sprintf("%s/auth/challenges/%s/verify", c.Endpoint, opts.AuthenticationChallengeID)
 	req, err := http.NewRequest("POST", endpoint, responseBody)
 	if err != nil {
 		log.Panic(err)

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -247,7 +247,7 @@ func (c *Client) ChallengeFactor(
 }
 
 // Verifies the one time password provided by the end-user.
-func (c *Client) VerifyFactor(
+func (c *Client) VerifyChallenge(
 	ctx context.Context,
 	opts VerifyOpts,
 ) (interface{}, error) {

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -216,12 +216,11 @@ func (c *Client) ChallengeFactor(
 	}
 
 	postBody, _ := json.Marshal(map[string]string{
-		"authentication_factor_id": opts.AuthenticationFactorID,
-		"sms_template":             opts.SMSTemplate,
+		"sms_template": opts.SMSTemplate,
 	})
 	responseBody := bytes.NewBuffer(postBody)
 
-	endpoint := fmt.Sprintf("%s/auth/factors/challenge", c.Endpoint)
+	endpoint := fmt.Sprintf("%s/auth/factors/%s/challenge", c.Endpoint, opts.AuthenticationFactorID)
 	req, err := http.NewRequest("POST", endpoint, responseBody)
 	if err != nil {
 		log.Panic(err)

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -265,8 +265,7 @@ func (c *Client) VerifyChallenge(
 	}
 
 	postBody, _ := json.Marshal(map[string]string{
-		"authentication_challenge_id": opts.AuthenticationChallengeID,
-		"code":                        opts.Code,
+		"code": opts.Code,
 	})
 	responseBody := bytes.NewBuffer(postBody)
 

--- a/pkg/mfa/client_test.go
+++ b/pkg/mfa/client_test.go
@@ -185,7 +185,7 @@ func challengeFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestVerifyFactor(t *testing.T) {
+func TestVerifyChallenge(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
@@ -215,14 +215,14 @@ func TestVerifyFactor(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(verifyFactorTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(verifyChallengeTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			response, err := client.VerifyFactor(context.Background(), test.options)
+			response, err := client.VerifyChallenge(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -233,7 +233,7 @@ func TestVerifyFactor(t *testing.T) {
 	}
 }
 
-func verifyFactorTestHandler(w http.ResponseWriter, r *http.Request) {
+func verifyChallengeTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)
@@ -257,7 +257,7 @@ func verifyFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestVerifyFactorError(t *testing.T) {
+func TestVerifyChallengeError(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
@@ -283,14 +283,14 @@ func TestVerifyFactorError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(verifyFactorErrorTestHandler))
+			server := httptest.NewServer(http.HandlerFunc(verifyChallengeErrorTestHandler))
 			defer server.Close()
 
 			client := test.client
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			response, err := client.VerifyFactor(context.Background(), test.options)
+			response, err := client.VerifyChallenge(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -301,7 +301,7 @@ func TestVerifyFactorError(t *testing.T) {
 	}
 }
 
-func verifyFactorErrorTestHandler(w http.ResponseWriter, r *http.Request) {
+func verifyChallengeErrorTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)

--- a/pkg/mfa/mfa.go
+++ b/pkg/mfa/mfa.go
@@ -39,3 +39,11 @@ func VerifyChallenge(
 ) (interface{}, error) {
 	return DefaultClient.VerifyChallenge(ctx, opts)
 }
+
+// Deprecated: Use VerifyChallenge instead
+func VerifyFactor(
+	ctx context.Context,
+	opts VerifyOpts,
+) (interface{}, error) {
+	return DefaultClient.VerifyFactor(ctx, opts)
+}

--- a/pkg/mfa/mfa.go
+++ b/pkg/mfa/mfa.go
@@ -32,10 +32,10 @@ func ChallengeFactor(
 	return DefaultClient.ChallengeFactor(ctx, opts)
 }
 
-// VerifyFactor verifies the one time password provided by the end-user.
-func VerifyFactor(
+// VerifyChallenge verifies the one time password provided by the end-user.
+func VerifyChallenge(
 	ctx context.Context,
 	opts VerifyOpts,
 ) (interface{}, error) {
-	return DefaultClient.VerifyFactor(ctx, opts)
+	return DefaultClient.VerifyChallenge(ctx, opts)
 }

--- a/pkg/mfa/mfa_test.go
+++ b/pkg/mfa/mfa_test.go
@@ -60,8 +60,8 @@ func TestMfaChallengeFactors(t *testing.T) {
 	require.Equal(t, expectedResponse, challengeResponse)
 }
 
-func TestVerifyFactors(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(verifyFactorTestHandler))
+func TestVerifyChallenges(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(verifyChallengeTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{
@@ -73,7 +73,7 @@ func TestVerifyFactors(t *testing.T) {
 	expectedResponse := VerifyResponse{
 		Valid: true,
 	}
-	verifyResponse, err := VerifyFactor(context.Background(), VerifyOpts{
+	verifyResponse, err := VerifyChallenge(context.Background(), VerifyOpts{
 		AuthenticationChallengeID: "auth_challenge_test123",
 		Code:                      "0000000",
 	})


### PR DESCRIPTION
This PR updates the endpoints used for two of the MFA operations:

- `ChallengeFactor`
- `VerifyChallenge`

The VerifyFactor method is now deprecated and has been replaced with VerifyChallenge. VerifyFactor will be removed in the next major version.

Resolves SDK-546.

I followed Godoc's deprecation:
https://go.dev/blog/godoc
