### PR TITLE
sso: Add GetLoginHandler to sso.Client

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -109,6 +109,21 @@ func (c *Client) init() {
 	}
 }
 
+// GetLoginHandler returns an http.Handler that redirects client to the appropriate
+// login provider.
+func (c *Client) GetLoginHandler(opts GetAuthorizationURLOptions) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, err := c.GetAuthorizationURL(opts)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		http.Redirect(w, r, u.String(), http.StatusSeeOther)
+	})
+}
+
 // GetAuthorizationURLOptions contains the options to pass in order to generate
 // an authorization url.
 type GetAuthorizationURLOptions struct {

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -39,19 +39,10 @@ func GetProfile(ctx context.Context, opts GetProfileOptions) (Profile, error) {
 	return DefaultClient.GetProfile(ctx, opts)
 }
 
-// Login return a http.Handler that redirects client to the appropriate
+// Login returns a http.Handler that redirects client to the appropriate
 // login provider.
 func Login(opts GetAuthorizationURLOptions) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		u, err := GetAuthorizationURL(opts)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(err.Error()))
-			return
-		}
-
-		http.Redirect(w, r, u.String(), http.StatusSeeOther)
-	})
+	return DefaultClient.GetLoginHandler(opts)
 }
 
 // GetConnection gets a Connection.

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -16,6 +16,12 @@ func TestLogin(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
+	DefaultClient = &Client{
+		Endpoint:   server.URL,
+		HTTPClient: server.Client(),
+	}
+	Configure("test", "client_123")
+
 	redirectURI := server.URL + "/callback"
 
 	profile := Profile{}
@@ -72,12 +78,6 @@ func TestLogin(t *testing.T) {
 	})
 
 	mux.HandleFunc("/sso/token", profileAndTokenTestHandler)
-
-	DefaultClient = &Client{
-		Endpoint:   server.URL,
-		HTTPClient: server.Client(),
-	}
-	Configure("test", "client_123")
 
 	res, err := server.Client().Get(server.URL + "/login")
 	require.NoError(t, err)


### PR DESCRIPTION
The `sso.Login` function was only available for `sso.DefaultClient` meaning the only way to use it was to set `sso.DefaultClient` first.

By moving the handler creation into `sso.Client`, any `Client` can now create a login handler that respects the client instances values.
