### PR TITLE
Clean inconsistencies on Audit Log Client

### DIFF
--- a/pkg/auditlogs/README.md
+++ b/pkg/auditlogs/README.md
@@ -21,12 +21,12 @@ func main() {
 	auditlogs.SetAPIKey("my_api_key")
 
 	// Wherever you need to publish an audit log event:
-	err := auditlogs.CreateEvent(ctx.Background(), auditlogs.AuditLogEventOpts{
+	err := auditlogs.CreateEvent(ctx.Background(), auditlogs.CreateEventOpts{
 		Organization: "org_8899300049990088",
 		Event: Event{
 			Action: "team.created",
 			Actor: Actor{
-				Id:   "o5fdfsdfUMCAuunNN3Iwfs34gMw",
+				ID:   "o5fdfsdfUMCAuunNN3Iwfs34gMw",
 				Name: "jonatas",
 				Type: "user",
 				Metadata: map[string]interface{}{
@@ -37,7 +37,7 @@ func main() {
 				Location: "79.226.116.209",
 			},
 			Targets: []Target{
-				Target{Id: "team_123", Type: "team"},
+				Target{ID: "team_123", Type: "team"},
 			},
 		},
 		IdempotencyKey: uuid.New().String(),

--- a/pkg/auditlogs/auditlogs.go
+++ b/pkg/auditlogs/auditlogs.go
@@ -6,12 +6,12 @@
 //	    auditlogs.SetAPIKey("my_api_key")
 //
 //	    // Wherever you need to publish an audit log event:
-//	    err := auditlogs.CreateEvent(context.Background(), auditlogs.AuditLogEventOpts{
+//	    err := auditlogs.CreateEvent(context.Background(), auditlogs.CreateEventOpts{
 //	        Organization: "org_8899300049990088",
 //			Event: Event{
 //				Action: "team.created",
 //				Actor: Actor{
-//					Id:   "o5fdfsdfUMCAuunNN3Iwfs34gMw",
+//					ID:   "o5fdfsdfUMCAuunNN3Iwfs34gMw",
 //					Name: "jonatas",
 //					Type: "user",
 //					Metadata: map[string]interface{}{
@@ -22,7 +22,7 @@
 //					Location: "79.226.116.209",
 //				},
 //				Targets: []Target{
-//					Target{Id: "team_123", Type: "team"},
+//					Target{ID: "team_123", Type: "team"},
 //				},
 //			},
 //			IdempotencyKey: uuid.New().String(),
@@ -51,16 +51,16 @@ func SetAPIKey(k string) {
 }
 
 // CreateEvent creates the given event.
-func CreateEvent(ctx context.Context, e AuditLogEventOpts) error {
+func CreateEvent(ctx context.Context, e CreateEventOpts) error {
 	return DefaultClient.CreateEvent(ctx, e)
 }
 
 // CreateEvent creates the given event.
-func CreateExport(ctx context.Context, e CreateExportOpts) (CreateExportResponse, error) {
+func CreateExport(ctx context.Context, e CreateExportOpts) (AuditLogExport, error) {
 	return DefaultClient.CreateExport(ctx, e)
 }
 
 // CreateEvent creates the given event.
-func GetExport(ctx context.Context, e GetExportOpts) (GetExportResponse, error) {
+func GetExport(ctx context.Context, e GetExportOpts) (AuditLogExport, error) {
 	return DefaultClient.GetExport(ctx, e)
 }

--- a/pkg/auditlogs/auditlogs_test.go
+++ b/pkg/auditlogs/auditlogs_test.go
@@ -25,13 +25,13 @@ func TestAuditLogsCreateEvent(t *testing.T) {
 
 	SetAPIKey("test")
 
-	err := CreateEvent(context.TODO(), AuditLogEventOpts{})
+	err := CreateEvent(context.TODO(), CreateEventOpts{})
 	require.NoError(t, err)
 }
 
 func TestAuditLogsCreateExport(t *testing.T) {
 	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
-		body := CreateExportResponse{}
+		body := AuditLogExport{}
 		payload, _ := json.Marshal(body)
 		w.Write(payload)
 		w.WriteHeader(http.StatusOK)
@@ -53,7 +53,7 @@ func TestAuditLogsCreateExport(t *testing.T) {
 
 func TestAuditLogsGetExport(t *testing.T) {
 	handlerFunc := func(w http.ResponseWriter, r *http.Request) {
-		body := GetExportResponse{}
+		body := AuditLogExport{}
 		payload, _ := json.Marshal(body)
 		w.Write(payload)
 		w.WriteHeader(http.StatusOK)

--- a/pkg/auditlogs/client_test.go
+++ b/pkg/auditlogs/client_test.go
@@ -12,19 +12,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var event = AuditLogEventOpts{
+var event = CreateEventOpts{
 	Organization: "org_123456",
 	Event: Event{
 		Action:     "document.updated",
 		OccurredAt: time.Now(),
 		Actor: Actor{
-			Id:   "user_1",
+			ID:   "user_1",
 			Name: "Jon Smith",
 			Type: "User",
 		},
 		Targets: []Target{
 			{
-				Id:   "document_39127",
+				ID:   "document_39127",
 				Type: "document",
 			},
 		},
@@ -55,7 +55,7 @@ func TestCreateEvent(t *testing.T) {
 		}
 		SetAPIKey("test")
 
-		err := CreateEvent(context.TODO(), AuditLogEventOpts{
+		err := CreateEvent(context.TODO(), CreateEventOpts{
 			IdempotencyKey: "the-idempotency-key",
 		})
 		require.Equal(t, handler.header.Get("Idempotency-Key"), "the-idempotency-key")
@@ -77,7 +77,7 @@ func TestCreateEvent(t *testing.T) {
 		}
 		SetAPIKey("test")
 
-		err := CreateEvent(context.TODO(), AuditLogEventOpts{})
+		err := CreateEvent(context.TODO(), CreateEventOpts{})
 		require.Equal(t, "a-request-id", err.(workos_errors.HTTPError).RequestID)
 		require.Error(t, err)
 	})
@@ -110,7 +110,7 @@ func TestCreateEvent(t *testing.T) {
 		}
 		SetAPIKey("test")
 
-		err := CreateEvent(context.TODO(), AuditLogEventOpts{})
+		err := CreateEvent(context.TODO(), CreateEventOpts{})
 		require.Error(t, err)
 
 		httpError := err.(workos_errors.HTTPError)
@@ -146,7 +146,7 @@ func TestCreateEvent(t *testing.T) {
 		}
 		SetAPIKey("test")
 
-		err := CreateEvent(context.TODO(), AuditLogEventOpts{})
+		err := CreateEvent(context.TODO(), CreateEventOpts{})
 		require.Error(t, err)
 
 		httpError := err.(workos_errors.HTTPError)
@@ -159,8 +159,8 @@ func TestCreateEvent(t *testing.T) {
 func TestCreateExports(t *testing.T) {
 	t.Run("Call succeeds", func(t *testing.T) {
 		handlerFunc := func(w http.ResponseWriter, r *http.Request) {
-			body, _ := json.Marshal(CreateExportResponse{
-				Id: "test",
+			body, _ := json.Marshal(AuditLogExport{
+				ID: "test",
 			})
 			w.WriteHeader(http.StatusCreated)
 			w.Write(body)
@@ -175,8 +175,8 @@ func TestCreateExports(t *testing.T) {
 		SetAPIKey("test")
 
 		body, err := CreateExport(context.TODO(), CreateExportOpts{})
-		require.Equal(t, body, CreateExportResponse{
-			Id: "test",
+		require.Equal(t, body, AuditLogExport{
+			ID: "test",
 		})
 		require.NoError(t, err)
 	})
@@ -190,8 +190,8 @@ func TestCreateExports(t *testing.T) {
 			require.Equal(t, opts.Targets[0], "user")
 			require.Equal(t, opts.Actors, []string{"Jon", "Smith"})
 
-			body, _ := json.Marshal(CreateExportResponse{
-				Id: "test123",
+			body, _ := json.Marshal(AuditLogExport{
+				ID: "test123",
 			})
 
 			w.Write(body)
@@ -211,8 +211,8 @@ func TestCreateExports(t *testing.T) {
 			Targets: []string{"user"},
 			Actors:  []string{"Jon", "Smith"},
 		})
-		require.Equal(t, body, CreateExportResponse{
-			Id: "test123",
+		require.Equal(t, body, AuditLogExport{
+			ID: "test123",
 		})
 		require.NoError(t, err)
 	})
@@ -237,8 +237,8 @@ func TestCreateExports(t *testing.T) {
 func TestGetExports(t *testing.T) {
 	t.Run("Call succeeds", func(t *testing.T) {
 		handlerFunc := func(w http.ResponseWriter, r *http.Request) {
-			body, _ := json.Marshal(GetExportResponse{
-				Id: "test",
+			body, _ := json.Marshal(AuditLogExport{
+				ID: "test",
 			})
 			w.WriteHeader(http.StatusCreated)
 			w.Write(body)
@@ -253,8 +253,8 @@ func TestGetExports(t *testing.T) {
 		SetAPIKey("test")
 
 		body, err := GetExport(context.TODO(), GetExportOpts{})
-		require.Equal(t, body, GetExportResponse{
-			Id: "test",
+		require.Equal(t, body, AuditLogExport{
+			ID: "test",
 		})
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
Clean some inconsistencies on the Audit Log Client:

- Every other piece of the Go SDK keeps correct Go casing with abbreviations (e.g. ID, URL, ConnectionID). Audit Logs stuff breaks this (OrganizationId, Id, Url)
- Every other piece of the Go SDK follows patterns to how objects and types are named. E.g. GetOrganizations() accepts GetOrganizationsOpts, and returns Organization, and so does every other function. However, in Audit Logs there is no pattern. E.g. CreateEvent() accepts AuditLogEventOpts.
- Every other piece of the Go SDK specifies enum-like string types. For Audit Logs enums are just marked as string. The IDE gives you no intellisense on these.
- Audit Logs Go SDK misses a common interface for an audit logs export. There is a GetExport() function, but it returns GetExportResponse.  There is also CreateExport() function, which returns CreateExportResponse, which is exactly the same object as the previous function returns. There is no common Export or AuditLogsExport interface like in other SDKs. - The type signatures make it look like they return different things, when in reality they are not. It’s a bit confusing to navigate the SDK even in the IDE. It also makes it harder to document things in the docs; it’s very unhuman-like to say that something gives you a GetExportResponse.

Resolves LOG-540