### PR TITLE
Standardise return type of VerifyChallenge and coalesce errors into Error

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v1.20.0"
+	Version = "v1.21.0"
 )

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -134,7 +134,7 @@ type VerifyOpts struct {
 
 type VerifyResponse struct {
 	// Return details of the request
-	Challenge ChallengeResponse
+	Challenge ChallengeResponse `json:"challenge"`
 
 	// Boolean returning if request is valid
 	Valid bool `json:"valid"`

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -288,7 +288,7 @@ type VerificationResponseError struct {
 	Message string
 }
 
-func (r *VerificationResponseError) Error() string {
+func (r VerificationResponseError) Error() string {
 	return fmt.Sprintf("code: %s. message: %v", r.Code, r.Message)
 }
 
@@ -330,7 +330,7 @@ func (c *Client) VerifyChallenge(
 	}
 
 	if body.Code != "" {
-		return VerifyChallengeResponse{}, &VerificationResponseError{body.Code, body.Message}
+		return VerifyChallengeResponse{}, VerificationResponseError{body.Code, body.Message}
 	}
 	return VerifyChallengeResponse{body.Challenge, body.Valid}, nil
 }

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -289,7 +289,7 @@ type VerificationResponseError struct {
 }
 
 func (r VerificationResponseError) Error() string {
-	return fmt.Sprintf("code: %s. message: %v", r.Code, r.Message)
+	return fmt.Sprintf("mfa verification failed: %s (code: %s)", r.Message, r.Code)
 }
 
 // Verifies the one time password provided by the end-user.

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -134,7 +134,7 @@ type VerifyOpts struct {
 
 type VerifyResponse struct {
 	// Return details of the request
-	Challenge map[string]interface{} `json:"challenge"`
+	Challenge ChallengeResponse
 
 	// Boolean returning if request is valid
 	Valid bool `json:"valid"`

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -263,11 +263,20 @@ func (c *Client) VerifyFactor(
 	return VerifyChallenge(ctx, opts)
 }
 
+type VerificationResponseError struct {
+	Code    string
+	Message string
+}
+
+func (r *VerificationResponseError) Error() string {
+	return fmt.Sprintf("code: %s. message: %v", r.Code, r.Message)
+}
+
 // Verifies the one time password provided by the end-user.
 func (c *Client) VerifyChallenge(
 	ctx context.Context,
 	opts VerifyOpts,
-) (interface{}, error) {
+) (VerifyResponse, error) {
 	c.once.Do(c.init)
 
 	if opts.AuthenticationChallengeID == "" {
@@ -296,13 +305,14 @@ func (c *Client) VerifyChallenge(
 	var body RawVerifyResponse
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&body)
-
-	if body.Code != "" {
-		return VerifyResponseError{body.Code, body.Message}, err
-	} else {
-		return VerifyResponse{body.Challenge, body.Valid}, err
+	if err != nil {
+		return VerifyResponse{}, err
 	}
 
+	if body.Code != "" {
+		return VerifyResponse{}, &VerificationResponseError{body.Code, body.Message}
+	}
+	return VerifyResponse{body.Challenge, body.Valid}, err
 }
 
 // Deletes an authentication factor.

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -312,7 +312,7 @@ func (c *Client) VerifyChallenge(
 	if body.Code != "" {
 		return VerifyResponse{}, &VerificationResponseError{body.Code, body.Message}
 	}
-	return VerifyResponse{body.Challenge, body.Valid}, err
+	return VerifyResponse{body.Challenge, body.Valid}, nil
 }
 
 // Deletes an authentication factor.

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -58,22 +58,32 @@ func (c *Client) init() {
 	}
 }
 
-// GetEnrollsOpts contains the options to create an Authentication Factor.
-type GetEnrollOpts struct {
+// Type represents the type of Authentication Factor
+type FactorType string
+
+// Constants that enumerate the available Types.
+const (
+	SMS  FactorType = "sms"
+	TOTP FactorType = "totp"
+)
+
+// EnrollFactorOpts contains the options to create an Authentication Factor.
+type EnrollFactorOpts struct {
+
 	// Type of factor to be enrolled (sms or totp).
-	Type string
+	Type FactorType
 
 	// Name of the Organization.
-	TotpIssuer string
+	TOTPIssuer string
 
 	// Email of user.
-	TotpUser string
+	TOTPUser string
 
 	// Phone Number of the User.
 	PhoneNumber string
 }
 
-type EnrollResponse struct {
+type Factor struct {
 	// The authentication factor's unique ID
 	ID string `json:"id"`
 
@@ -87,24 +97,34 @@ type EnrollResponse struct {
 	UpdatedAt string `json:"updated_at"`
 
 	// The type of request either 'sms' or 'totp'
-	Type string `json:"type"`
+	Type FactorType `json:"type"`
 
-	// Details of the totp response will be 'null' if using sms
-	Totp map[string]interface{} `json:"totp"`
+	// Details of the totp response will be 'null' if using sms\
+	TOTP TOTPDetails `json:"totp"`
 
 	// Details of the sms response will be 'null' if using totp
-	Sms map[string]interface{} `json:"sms"`
+	SMS SMSDetails `json:"sms"`
+}
+
+type TOTPDetails struct {
+	QRCode string `json:"qr_code"`
+	Secret string `json:"secret"`
+	URI    string `json:"uri"`
+}
+
+type SMSDetails struct {
+	PhoneNumber string `json:"phone_number"`
 }
 
 type ChallengeOpts struct {
 	// ID of the authorization factor.
-	AuthenticationFactorID string
+	FactorID string
 
 	// Parameter to customize the message for sms type factors. Must include "{{code}}" if used (opt).
 	SMSTemplate string
 }
 
-type ChallengeResponse struct {
+type Challenge struct {
 	// The authentication challenge's unique ID
 	ID string `json:"id"`
 
@@ -121,10 +141,10 @@ type ChallengeResponse struct {
 	ExpiresAt string `json:"expires_at"`
 
 	// The authentication factor Id used to create the request.
-	AuthenticationFactorID string `json:"authentication_factor_id"`
+	FactorID string `json:"authentication_factor_id"`
 }
 
-type VerifyOpts struct {
+type VerifyChallengeOpts struct {
 	// The ID of the authentication challenge that provided the user the verification code.
 	AuthenticationChallengeID string
 
@@ -132,15 +152,15 @@ type VerifyOpts struct {
 	Code string
 }
 
-type VerifyResponse struct {
+type VerifyChallengeResponse struct {
 	// Return details of the request
-	Challenge ChallengeResponse `json:"challenge"`
+	Challenge Challenge `json:"challenge"`
 
 	// Boolean returning if request is valid
 	Valid bool `json:"valid"`
 }
 
-type VerifyResponseError struct {
+type VerifyChallengeResponseError struct {
 	// Returns string of error code on response with valid: false
 	Code string `json:"code"`
 
@@ -148,44 +168,44 @@ type VerifyResponseError struct {
 	Message string `json:"message"`
 }
 
-type RawVerifyResponse struct {
-	VerifyResponse
-	VerifyResponseError
+type RawVerifyChallengeResponse struct {
+	VerifyChallengeResponse
+	VerifyChallengeResponseError
 }
 
 type DeleteFactorOpts struct {
 	// ID of factor to be deleted
-	AuthenticationFactorID string
+	FactorID string
 }
 
 type GetFactorOpts struct {
 	// ID of the factor.
-	AuthenticationFactorID string
+	FactorID string
 }
 
 // Create an Authentication Factor.
 func (c *Client) EnrollFactor(
 	ctx context.Context,
-	opts GetEnrollOpts,
-) (EnrollResponse, error) {
+	opts EnrollFactorOpts,
+) (Factor, error) {
 	c.once.Do(c.init)
 
-	if opts.Type == "" || (opts.Type != "sms" && opts.Type != "totp") {
-		return EnrollResponse{}, ErrInvalidType
+	if opts.Type == "" || (opts.Type != SMS && opts.Type != TOTP) {
+		return Factor{}, ErrInvalidType
 	}
 
-	if opts.Type == "totp" && (opts.TotpIssuer == "" || opts.TotpUser == "") {
-		return EnrollResponse{}, ErrIncompleteArgs
+	if opts.Type == TOTP && (opts.TOTPIssuer == "" || opts.TOTPUser == "") {
+		return Factor{}, ErrIncompleteArgs
 	}
 
-	if opts.Type == "sms" && opts.PhoneNumber == "" {
-		return EnrollResponse{}, ErrNoPhoneNumber
+	if opts.Type == SMS && opts.PhoneNumber == "" {
+		return Factor{}, ErrNoPhoneNumber
 	}
 
 	postBody, _ := json.Marshal(map[string]string{
-		"type":         opts.Type,
-		"totp_issuer":  opts.TotpIssuer,
-		"totp_user":    opts.TotpUser,
+		"type":         string(opts.Type),
+		"totp_issuer":  opts.TOTPIssuer,
+		"totp_user":    opts.TOTPUser,
 		"phone_number": opts.PhoneNumber,
 	})
 	responseBody := bytes.NewBuffer(postBody)
@@ -201,14 +221,14 @@ func (c *Client) EnrollFactor(
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return EnrollResponse{}, err
+		return Factor{}, err
 	}
 
 	if err = workos_errors.TryGetHTTPError(resp); err != nil {
-		return EnrollResponse{}, err
+		return Factor{}, err
 	}
 
-	var body EnrollResponse
+	var body Factor
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&body)
 	return body, err
@@ -218,11 +238,11 @@ func (c *Client) EnrollFactor(
 func (c *Client) ChallengeFactor(
 	ctx context.Context,
 	opts ChallengeOpts,
-) (ChallengeResponse, error) {
+) (Challenge, error) {
 	c.once.Do(c.init)
 
-	if opts.AuthenticationFactorID == "" {
-		return ChallengeResponse{}, ErrMissingAuthId
+	if opts.FactorID == "" {
+		return Challenge{}, ErrMissingAuthId
 	}
 
 	postBody, _ := json.Marshal(map[string]string{
@@ -230,7 +250,7 @@ func (c *Client) ChallengeFactor(
 	})
 	responseBody := bytes.NewBuffer(postBody)
 
-	endpoint := fmt.Sprintf("%s/auth/factors/%s/challenge", c.Endpoint, opts.AuthenticationFactorID)
+	endpoint := fmt.Sprintf("%s/auth/factors/%s/challenge", c.Endpoint, opts.FactorID)
 	req, err := http.NewRequest("POST", endpoint, responseBody)
 	if err != nil {
 		log.Panic(err)
@@ -241,14 +261,14 @@ func (c *Client) ChallengeFactor(
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return ChallengeResponse{}, err
+		return Challenge{}, err
 	}
 
 	if err = workos_errors.TryGetHTTPError(resp); err != nil {
-		return ChallengeResponse{}, err
+		return Challenge{}, err
 	}
 
-	var body ChallengeResponse
+	var body Challenge
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&body)
 	return body, err
@@ -258,7 +278,7 @@ func (c *Client) ChallengeFactor(
 // Deprecated: Use VerifyChallenge instead.
 func (c *Client) VerifyFactor(
 	ctx context.Context,
-	opts VerifyOpts,
+	opts VerifyChallengeOpts,
 ) (interface{}, error) {
 	return VerifyChallenge(ctx, opts)
 }
@@ -275,12 +295,12 @@ func (r *VerificationResponseError) Error() string {
 // Verifies the one time password provided by the end-user.
 func (c *Client) VerifyChallenge(
 	ctx context.Context,
-	opts VerifyOpts,
-) (VerifyResponse, error) {
+	opts VerifyChallengeOpts,
+) (VerifyChallengeResponse, error) {
 	c.once.Do(c.init)
 
 	if opts.AuthenticationChallengeID == "" {
-		return VerifyResponse{}, ErrMissingChallengeId
+		return VerifyChallengeResponse{}, ErrMissingChallengeId
 	}
 
 	postBody, _ := json.Marshal(map[string]string{
@@ -299,20 +319,20 @@ func (c *Client) VerifyChallenge(
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return VerifyResponse{}, err
+		return VerifyChallengeResponse{}, err
 	}
 
-	var body RawVerifyResponse
+	var body RawVerifyChallengeResponse
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&body)
 	if err != nil {
-		return VerifyResponse{}, err
+		return VerifyChallengeResponse{}, err
 	}
 
 	if body.Code != "" {
-		return VerifyResponse{}, &VerificationResponseError{body.Code, body.Message}
+		return VerifyChallengeResponse{}, &VerificationResponseError{body.Code, body.Message}
 	}
-	return VerifyResponse{body.Challenge, body.Valid}, nil
+	return VerifyChallengeResponse{body.Challenge, body.Valid}, nil
 }
 
 // Deletes an authentication factor.
@@ -325,7 +345,7 @@ func (c *Client) DeleteFactor(
 	endpoint := fmt.Sprintf(
 		"%s/auth/factors/%s",
 		c.Endpoint,
-		opts.AuthenticationFactorID,
+		opts.FactorID,
 	)
 	req, err := http.NewRequest(
 		http.MethodDelete,
@@ -354,13 +374,13 @@ func (c *Client) DeleteFactor(
 func (c *Client) GetFactor(
 	ctx context.Context,
 	opts GetFactorOpts,
-) (EnrollResponse, error) {
+) (Factor, error) {
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf(
 		"%s/auth/factors/%s",
 		c.Endpoint,
-		opts.AuthenticationFactorID,
+		opts.FactorID,
 	)
 	req, err := http.NewRequest(
 		http.MethodGet,
@@ -368,7 +388,7 @@ func (c *Client) GetFactor(
 		nil,
 	)
 	if err != nil {
-		return EnrollResponse{}, err
+		return Factor{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -378,15 +398,15 @@ func (c *Client) GetFactor(
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return EnrollResponse{}, err
+		return Factor{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos_errors.TryGetHTTPError(res); err != nil {
-		return EnrollResponse{}, err
+		return Factor{}, err
 	}
 
-	var body EnrollResponse
+	var body Factor
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -99,7 +99,7 @@ type Factor struct {
 	// The type of request either 'sms' or 'totp'
 	Type FactorType `json:"type"`
 
-	// Details of the totp response will be 'null' if using sms\
+	// Details of the totp response will be 'null' if using sms
 	TOTP TOTPDetails `json:"totp"`
 
 	// Details of the sms response will be 'null' if using totp

--- a/pkg/mfa/client_test.go
+++ b/pkg/mfa/client_test.go
@@ -16,7 +16,7 @@ func TestGetFactor(t *testing.T) {
 		scenario string
 		client   *Client
 		options  GetFactorOpts
-		expected EnrollResponse
+		expected Factor
 		err      bool
 	}{
 		{
@@ -30,9 +30,9 @@ func TestGetFactor(t *testing.T) {
 				APIKey: "test",
 			},
 			options: GetFactorOpts{
-				AuthenticationFactorID: "auth_factor_test123",
+				FactorID: "auth_factor_test123",
 			},
-			expected: EnrollResponse{
+			expected: Factor{
 				ID:        "auth_factor_test123",
 				CreatedAt: "2022-02-17T22:39:26.616Z",
 				UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -98,8 +98,8 @@ func TestEnrollFactor(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetEnrollOpts
-		expected EnrollResponse
+		options  EnrollFactorOpts
+		expected Factor
 		err      bool
 	}{
 		{
@@ -112,12 +112,12 @@ func TestEnrollFactor(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: GetEnrollOpts{
+			options: EnrollFactorOpts{
 				Type:       "totp",
-				TotpIssuer: "WorkOS",
-				TotpUser:   "some_user",
+				TOTPIssuer: "WorkOS",
+				TOTPUser:   "some_user",
 			},
-			expected: EnrollResponse{
+			expected: Factor{
 				ID:        "auth_factor_test123",
 				CreatedAt: "2022-02-17T22:39:26.616Z",
 				UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -129,11 +129,11 @@ func TestEnrollFactor(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: GetEnrollOpts{
+			options: EnrollFactorOpts{
 				Type:        "sms",
 				PhoneNumber: "0000000000",
 			},
-			expected: EnrollResponse{
+			expected: Factor{
 				ID:        "auth_factor_test123",
 				CreatedAt: "2022-02-17T22:39:26.616Z",
 				UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -174,7 +174,7 @@ func enrollFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(EnrollResponse{
+	body, err := json.Marshal(Factor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -194,7 +194,7 @@ func TestChallengeFactor(t *testing.T) {
 		scenario string
 		client   *Client
 		options  ChallengeOpts
-		expected ChallengeResponse
+		expected Challenge
 		err      bool
 	}{
 		{
@@ -208,14 +208,14 @@ func TestChallengeFactor(t *testing.T) {
 				APIKey: "test",
 			},
 			options: ChallengeOpts{
-				AuthenticationFactorID: "auth_factor_id",
+				FactorID: "auth_factor_id",
 			},
-			expected: ChallengeResponse{
-				ID:                     "auth_challenge_test123",
-				CreatedAt:              "2022-02-17T22:39:26.616Z",
-				UpdatedAt:              "2022-02-17T22:39:26.616Z",
-				AuthenticationFactorID: "auth_factor_test123",
-				ExpiresAt:              "2022-02-17T22:39:26.616Z",
+			expected: Challenge{
+				ID:        "auth_challenge_test123",
+				CreatedAt: "2022-02-17T22:39:26.616Z",
+				UpdatedAt: "2022-02-17T22:39:26.616Z",
+				FactorID:  "auth_factor_test123",
+				ExpiresAt: "2022-02-17T22:39:26.616Z",
 			},
 		},
 	}
@@ -252,12 +252,12 @@ func challengeFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(ChallengeResponse{
-		ID:                     "auth_challenge_test123",
-		CreatedAt:              "2022-02-17T22:39:26.616Z",
-		UpdatedAt:              "2022-02-17T22:39:26.616Z",
-		AuthenticationFactorID: "auth_factor_test123",
-		ExpiresAt:              "2022-02-17T22:39:26.616Z",
+	body, err := json.Marshal(Challenge{
+		ID:        "auth_challenge_test123",
+		CreatedAt: "2022-02-17T22:39:26.616Z",
+		UpdatedAt: "2022-02-17T22:39:26.616Z",
+		FactorID:  "auth_factor_test123",
+		ExpiresAt: "2022-02-17T22:39:26.616Z",
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -272,8 +272,8 @@ func TestVerifyChallenge(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  VerifyOpts
-		expected VerifyResponse
+		options  VerifyChallengeOpts
+		expected VerifyChallengeResponse
 		err      bool
 	}{
 		{
@@ -286,11 +286,11 @@ func TestVerifyChallenge(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: VerifyOpts{
+			options: VerifyChallengeOpts{
 				AuthenticationChallengeID: "auth_challenge_test123",
 				Code:                      "0000000",
 			},
-			expected: VerifyResponse{
+			expected: VerifyChallengeResponse{
 				Valid: true,
 			},
 		},
@@ -323,7 +323,7 @@ func getFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(EnrollResponse{
+	body, err := json.Marshal(Factor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -361,7 +361,7 @@ func verifyChallengeTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(VerifyResponse{
+	body, err := json.Marshal(VerifyChallengeResponse{
 		Valid: true,
 	})
 	if err != nil {
@@ -377,7 +377,7 @@ func TestVerifyChallengeError(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  VerifyOpts
+		options  VerifyChallengeOpts
 		expected VerificationResponseError
 		err      bool
 	}{
@@ -386,7 +386,7 @@ func TestVerifyChallengeError(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: VerifyOpts{
+			options: VerifyChallengeOpts{
 				AuthenticationChallengeID: "auth_challenge_test123",
 				Code:                      "0000000",
 			},
@@ -428,7 +428,7 @@ func verifyChallengeErrorTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(VerifyResponseError{
+	body, err := json.Marshal(VerifyChallengeResponseError{
 		Code:    "authentication_challenge_expired",
 		Message: "The authentication challenge 'auth_challenge_1234' has expired.",
 	})

--- a/pkg/mfa/client_test.go
+++ b/pkg/mfa/client_test.go
@@ -378,7 +378,7 @@ func TestVerifyChallengeError(t *testing.T) {
 		scenario string
 		client   *Client
 		options  VerifyOpts
-		expected VerifyResponseError
+		expected VerificationResponseError
 		err      bool
 	}{
 		{
@@ -390,7 +390,7 @@ func TestVerifyChallengeError(t *testing.T) {
 				AuthenticationChallengeID: "auth_challenge_test123",
 				Code:                      "0000000",
 			},
-			expected: VerifyResponseError{
+			expected: VerificationResponseError{
 				Code:    "authentication_challenge_expired",
 				Message: "The authentication challenge 'auth_challenge_1234' has expired.",
 			},
@@ -406,13 +406,12 @@ func TestVerifyChallengeError(t *testing.T) {
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			response, err := client.VerifyChallenge(context.Background(), test.options)
+			_, err := client.VerifyChallenge(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
 			}
-			require.NoError(t, err)
-			require.Equal(t, test.expected, response)
+			require.Equal(t, test.expected.Error(), err.Error())
 		})
 	}
 }

--- a/pkg/mfa/mfa.go
+++ b/pkg/mfa/mfa.go
@@ -19,8 +19,8 @@ func SetAPIKey(apiKey string) {
 // EnrollFactor creates a MFA authorization factor.
 func EnrollFactor(
 	ctx context.Context,
-	opts GetEnrollOpts,
-) (EnrollResponse, error) {
+	opts EnrollFactorOpts,
+) (Factor, error) {
 	return DefaultClient.EnrollFactor(ctx, opts)
 }
 
@@ -28,22 +28,22 @@ func EnrollFactor(
 func ChallengeFactor(
 	ctx context.Context,
 	opts ChallengeOpts,
-) (ChallengeResponse, error) {
+) (Challenge, error) {
 	return DefaultClient.ChallengeFactor(ctx, opts)
 }
 
 // VerifyChallenge verifies the one time password provided by the end-user.
 func VerifyChallenge(
 	ctx context.Context,
-	opts VerifyOpts,
-) (VerifyResponse, error) {
+	opts VerifyChallengeOpts,
+) (VerifyChallengeResponse, error) {
 	return DefaultClient.VerifyChallenge(ctx, opts)
 }
 
 // Deprecated: Use VerifyChallenge instead
 func VerifyFactor(
 	ctx context.Context,
-	opts VerifyOpts,
+	opts VerifyChallengeOpts,
 ) (interface{}, error) {
 	return DefaultClient.VerifyFactor(ctx, opts)
 }
@@ -60,6 +60,6 @@ func DeleteFactor(
 func GetFactor(
 	ctx context.Context,
 	opts GetFactorOpts,
-) (EnrollResponse, error) {
+) (Factor, error) {
 	return DefaultClient.GetFactor(ctx, opts)
 }

--- a/pkg/mfa/mfa.go
+++ b/pkg/mfa/mfa.go
@@ -36,7 +36,7 @@ func ChallengeFactor(
 func VerifyChallenge(
 	ctx context.Context,
 	opts VerifyOpts,
-) (interface{}, error) {
+) (VerifyResponse, error) {
 	return DefaultClient.VerifyChallenge(ctx, opts)
 }
 

--- a/pkg/mfa/mfa_test.go
+++ b/pkg/mfa/mfa_test.go
@@ -19,20 +19,20 @@ func TestMfaEnrollFactors(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := EnrollResponse{
+	expectedResponse := Factor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
 		Type:      "generic_otp",
 	}
-	enrollResponse, err := EnrollFactor(context.Background(), GetEnrollOpts{
+	factor, err := EnrollFactor(context.Background(), EnrollFactorOpts{
 		Type:       "totp",
-		TotpIssuer: "WorkOS",
-		TotpUser:   "some_user",
+		TOTPIssuer: "WorkOS",
+		TOTPUser:   "some_user",
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, enrollResponse)
+	require.Equal(t, expectedResponse, factor)
 }
 
 func TestMfaChallengeFactors(t *testing.T) {
@@ -45,19 +45,19 @@ func TestMfaChallengeFactors(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := ChallengeResponse{
-		ID:                     "auth_challenge_test123",
-		CreatedAt:              "2022-02-17T22:39:26.616Z",
-		UpdatedAt:              "2022-02-17T22:39:26.616Z",
-		AuthenticationFactorID: "auth_factor_test123",
-		ExpiresAt:              "2022-02-17T22:39:26.616Z",
+	expectedResponse := Challenge{
+		ID:        "auth_challenge_test123",
+		CreatedAt: "2022-02-17T22:39:26.616Z",
+		UpdatedAt: "2022-02-17T22:39:26.616Z",
+		FactorID:  "auth_factor_test123",
+		ExpiresAt: "2022-02-17T22:39:26.616Z",
 	}
-	challengeResponse, err := ChallengeFactor(context.Background(), ChallengeOpts{
-		AuthenticationFactorID: "auth_factor_id",
+	challenge, err := ChallengeFactor(context.Background(), ChallengeOpts{
+		FactorID: "auth_factor_id",
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, challengeResponse)
+	require.Equal(t, expectedResponse, challenge)
 }
 
 func TestVerifyChallenges(t *testing.T) {
@@ -70,16 +70,16 @@ func TestVerifyChallenges(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := VerifyResponse{
+	expectedResponse := VerifyChallengeResponse{
 		Valid: true,
 	}
-	verifyResponse, err := VerifyChallenge(context.Background(), VerifyOpts{
+	verifyChallengeResponse, err := VerifyChallenge(context.Background(), VerifyChallengeOpts{
 		AuthenticationChallengeID: "auth_challenge_test123",
 		Code:                      "0000000",
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, verifyResponse)
+	require.Equal(t, expectedResponse, verifyChallengeResponse)
 }
 
 func TestGetFactors(t *testing.T) {
@@ -92,14 +92,14 @@ func TestGetFactors(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := EnrollResponse{
+	expectedResponse := Factor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
 		Type:      "generic_otp",
 	}
 	factorResponse, err := GetFactor(context.Background(), GetFactorOpts{
-		AuthenticationFactorID: "auth_factor_test123",
+		FactorID: "auth_factor_test123",
 	})
 
 	require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestDeleteFactors(t *testing.T) {
 	err := DeleteFactor(
 		context.Background(),
 		DeleteFactorOpts{
-			AuthenticationFactorID: "auth_factor_test1231",
+			FactorID: "auth_factor_test1231",
 		},
 	)
 


### PR DESCRIPTION
Prefer strongly typed return types to interface{} and map[string]interface{}. Don't use two separate Error like return values.