### PR TITLE
MFA Improvements

### DIFF
--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -59,19 +59,19 @@ func (c *Client) init() {
 }
 
 // Type represents the type of Authentication Factor
-type Type string
+type FactorType string
 
 // Constants that enumerate the available Types.
 const (
-	SMS  Type = "sms"
-	TOTP Type = "totp"
+	SMS  FactorType = "sms"
+	TOTP FactorType = "totp"
 )
 
 // EnrollFactorOpts contains the options to create an Authentication Factor.
 type EnrollFactorOpts struct {
 
 	// Type of factor to be enrolled (sms or totp).
-	Type Type
+	Type FactorType
 
 	// Name of the Organization.
 	TOTPIssuer string
@@ -97,7 +97,7 @@ type AuthenticationFactor struct {
 	UpdatedAt string `json:"updated_at"`
 
 	// The type of request either 'sms' or 'totp'
-	Type Type `json:"type"`
+	Type FactorType `json:"type"`
 
 	// Details of the totp response will be 'null' if using sms\
 	TOTP TOTPDetails `json:"totp"`

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -67,7 +67,7 @@ const (
 	TOTP Type = "totp"
 )
 
-// GetEnrollsOpts contains the options to create an Authentication Factor.
+// EnrollFactorOpts contains the options to create an Authentication Factor.
 type EnrollFactorOpts struct {
 
 	// Type of factor to be enrolled (sms or totp).
@@ -115,6 +115,7 @@ type TOTPDetails struct {
 type SMSDetails struct {
 	PhoneNumber string `json:"phone_number"`
 }
+
 type ChallengeOpts struct {
 	// ID of the authorization factor.
 	AuthenticationFactorID string

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -99,14 +99,22 @@ type AuthenticationFactor struct {
 	// The type of request either 'sms' or 'totp'
 	Type Type `json:"type"`
 
-	// Details of the totp response will be 'null' if using sms
-	//fix this from being a string
-	TOTP map[string]interface{} `json:"totp"`
+	// Details of the totp response will be 'null' if using sms\
+	TOTP TOTPDetails `json:"totp"`
 
 	// Details of the sms response will be 'null' if using totp
-	SMS map[string]interface{} `json:"sms"`
+	SMS SMSDetails `json:"sms"`
 }
 
+type TOTPDetails struct {
+	QRCode string `json:"qr_code"`
+	Secret string `json:"secret"`
+	URI    string `json:"uri"`
+}
+
+type SMSDetails struct {
+	PhoneNumber string `json:"phone_number"`
+}
 type ChallengeOpts struct {
 	// ID of the authorization factor.
 	AuthenticationFactorID string
@@ -185,7 +193,7 @@ func (c *Client) EnrollFactor(
 		return AuthenticationFactor{}, ErrInvalidType
 	}
 
-	if opts.Type == "totp" && (opts.TotpIssuer == "" || opts.TotpUser == "") {
+	if opts.Type == "totp" && (opts.TOTPIssuer == "" || opts.TOTPUser == "") {
 		return AuthenticationFactor{}, ErrIncompleteArgs
 	}
 
@@ -195,8 +203,8 @@ func (c *Client) EnrollFactor(
 
 	postBody, _ := json.Marshal(map[string]string{
 		"type":         string(opts.Type),
-		"totp_issuer":  opts.TotpIssuer,
-		"totp_user":    opts.TotpUser,
+		"totp_issuer":  opts.TOTPIssuer,
+		"totp_user":    opts.TOTPUser,
 		"phone_number": opts.PhoneNumber,
 	})
 	responseBody := bytes.NewBuffer(postBody)

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -154,7 +154,7 @@ type VerifyChallengeOpts struct {
 
 type VerifyResponse struct {
 	// Return details of the request
-	Challenge ChallengeResponse `json:"challenge"`
+	Challenge Challenge `json:"challenge"`
 
 	// Boolean returning if request is valid
 	Valid bool `json:"valid"`

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -190,15 +190,15 @@ func (c *Client) EnrollFactor(
 ) (Factor, error) {
 	c.once.Do(c.init)
 
-	if opts.Type == "" || (opts.Type != "sms" && opts.Type != "totp") {
+	if opts.Type == "" || (opts.Type != SMS && opts.Type != TOTP) {
 		return Factor{}, ErrInvalidType
 	}
 
-	if opts.Type == "totp" && (opts.TOTPIssuer == "" || opts.TOTPUser == "") {
+	if opts.Type == TOTP && (opts.TOTPIssuer == "" || opts.TOTPUser == "") {
 		return Factor{}, ErrIncompleteArgs
 	}
 
-	if opts.Type == "sms" && opts.PhoneNumber == "" {
+	if opts.Type == SMS && opts.PhoneNumber == "" {
 		return Factor{}, ErrNoPhoneNumber
 	}
 

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -152,7 +152,7 @@ type VerifyChallengeOpts struct {
 	Code string
 }
 
-type VerifyResponse struct {
+type VerifyChallengeResponse struct {
 	// Return details of the request
 	Challenge Challenge `json:"challenge"`
 
@@ -160,7 +160,7 @@ type VerifyResponse struct {
 	Valid bool `json:"valid"`
 }
 
-type VerifyResponseError struct {
+type VerifyChallengeResponseError struct {
 	// Returns string of error code on response with valid: false
 	Code string `json:"code"`
 
@@ -168,9 +168,9 @@ type VerifyResponseError struct {
 	Message string `json:"message"`
 }
 
-type RawVerifyResponse struct {
-	VerifyResponse
-	VerifyResponseError
+type RawVerifyChallengeResponse struct {
+	VerifyChallengeResponse
+	VerifyChallengeResponseError
 }
 
 type DeleteFactorOpts struct {
@@ -296,11 +296,11 @@ func (r *VerificationResponseError) Error() string {
 func (c *Client) VerifyChallenge(
 	ctx context.Context,
 	opts VerifyChallengeOpts,
-) (VerifyResponse, error) {
+) (VerifyChallengeResponse, error) {
 	c.once.Do(c.init)
 
 	if opts.AuthenticationChallengeID == "" {
-		return VerifyResponse{}, ErrMissingChallengeId
+		return VerifyChallengeResponse{}, ErrMissingChallengeId
 	}
 
 	postBody, _ := json.Marshal(map[string]string{
@@ -319,20 +319,20 @@ func (c *Client) VerifyChallenge(
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return VerifyResponse{}, err
+		return VerifyChallengeResponse{}, err
 	}
 
-	var body RawVerifyResponse
+	var body RawVerifyChallengeResponse
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&body)
 	if err != nil {
-		return VerifyResponse{}, err
+		return VerifyChallengeResponse{}, err
 	}
 
 	if body.Code != "" {
-		return VerifyResponse{}, &VerificationResponseError{body.Code, body.Message}
+		return VerifyChallengeResponse{}, &VerificationResponseError{body.Code, body.Message}
 	}
-	return VerifyResponse{body.Challenge, body.Valid}, nil
+	return VerifyChallengeResponse{body.Challenge, body.Valid}, nil
 }
 
 // Deletes an authentication factor.

--- a/pkg/mfa/client_test.go
+++ b/pkg/mfa/client_test.go
@@ -114,8 +114,8 @@ func TestEnrollFactor(t *testing.T) {
 			},
 			options: EnrollFactorOpts{
 				Type:       "totp",
-				TotpIssuer: "WorkOS",
-				TotpUser:   "some_user",
+				TOTPIssuer: "WorkOS",
+				TOTPUser:   "some_user",
 			},
 			expected: AuthenticationFactor{
 				ID:        "auth_factor_test123",

--- a/pkg/mfa/client_test.go
+++ b/pkg/mfa/client_test.go
@@ -16,7 +16,7 @@ func TestGetFactor(t *testing.T) {
 		scenario string
 		client   *Client
 		options  GetFactorOpts
-		expected AuthenticationFactor
+		expected Factor
 		err      bool
 	}{
 		{
@@ -30,9 +30,9 @@ func TestGetFactor(t *testing.T) {
 				APIKey: "test",
 			},
 			options: GetFactorOpts{
-				AuthenticationFactorID: "auth_factor_test123",
+				FactorID: "auth_factor_test123",
 			},
-			expected: AuthenticationFactor{
+			expected: Factor{
 				ID:        "auth_factor_test123",
 				CreatedAt: "2022-02-17T22:39:26.616Z",
 				UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -99,7 +99,7 @@ func TestEnrollFactor(t *testing.T) {
 		scenario string
 		client   *Client
 		options  EnrollFactorOpts
-		expected AuthenticationFactor
+		expected Factor
 		err      bool
 	}{
 		{
@@ -117,7 +117,7 @@ func TestEnrollFactor(t *testing.T) {
 				TOTPIssuer: "WorkOS",
 				TOTPUser:   "some_user",
 			},
-			expected: AuthenticationFactor{
+			expected: Factor{
 				ID:        "auth_factor_test123",
 				CreatedAt: "2022-02-17T22:39:26.616Z",
 				UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -133,7 +133,7 @@ func TestEnrollFactor(t *testing.T) {
 				Type:        "sms",
 				PhoneNumber: "0000000000",
 			},
-			expected: AuthenticationFactor{
+			expected: Factor{
 				ID:        "auth_factor_test123",
 				CreatedAt: "2022-02-17T22:39:26.616Z",
 				UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -174,7 +174,7 @@ func enrollFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(AuthenticationFactor{
+	body, err := json.Marshal(Factor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -208,14 +208,14 @@ func TestChallengeFactor(t *testing.T) {
 				APIKey: "test",
 			},
 			options: ChallengeOpts{
-				AuthenticationFactorID: "auth_factor_id",
+				FactorID: "auth_factor_id",
 			},
 			expected: Challenge{
-				ID:                     "auth_challenge_test123",
-				CreatedAt:              "2022-02-17T22:39:26.616Z",
-				UpdatedAt:              "2022-02-17T22:39:26.616Z",
-				AuthenticationFactorID: "auth_factor_test123",
-				ExpiresAt:              "2022-02-17T22:39:26.616Z",
+				ID:        "auth_challenge_test123",
+				CreatedAt: "2022-02-17T22:39:26.616Z",
+				UpdatedAt: "2022-02-17T22:39:26.616Z",
+				FactorID:  "auth_factor_test123",
+				ExpiresAt: "2022-02-17T22:39:26.616Z",
 			},
 		},
 	}
@@ -253,11 +253,11 @@ func challengeFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(Challenge{
-		ID:                     "auth_challenge_test123",
-		CreatedAt:              "2022-02-17T22:39:26.616Z",
-		UpdatedAt:              "2022-02-17T22:39:26.616Z",
-		AuthenticationFactorID: "auth_factor_test123",
-		ExpiresAt:              "2022-02-17T22:39:26.616Z",
+		ID:        "auth_challenge_test123",
+		CreatedAt: "2022-02-17T22:39:26.616Z",
+		UpdatedAt: "2022-02-17T22:39:26.616Z",
+		FactorID:  "auth_factor_test123",
+		ExpiresAt: "2022-02-17T22:39:26.616Z",
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -323,7 +323,7 @@ func getFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(AuthenticationFactor{
+	body, err := json.Marshal(Factor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",

--- a/pkg/mfa/client_test.go
+++ b/pkg/mfa/client_test.go
@@ -273,7 +273,7 @@ func TestVerifyChallenge(t *testing.T) {
 		scenario string
 		client   *Client
 		options  VerifyChallengeOpts
-		expected VerifyResponse
+		expected VerifyChallengeResponse
 		err      bool
 	}{
 		{
@@ -290,7 +290,7 @@ func TestVerifyChallenge(t *testing.T) {
 				AuthenticationChallengeID: "auth_challenge_test123",
 				Code:                      "0000000",
 			},
-			expected: VerifyResponse{
+			expected: VerifyChallengeResponse{
 				Valid: true,
 			},
 		},
@@ -361,7 +361,7 @@ func verifyChallengeTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(VerifyResponse{
+	body, err := json.Marshal(VerifyChallengeResponse{
 		Valid: true,
 	})
 	if err != nil {
@@ -428,7 +428,7 @@ func verifyChallengeErrorTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(VerifyResponseError{
+	body, err := json.Marshal(VerifyChallengeResponseError{
 		Code:    "authentication_challenge_expired",
 		Message: "The authentication challenge 'auth_challenge_1234' has expired.",
 	})

--- a/pkg/mfa/client_test.go
+++ b/pkg/mfa/client_test.go
@@ -16,7 +16,7 @@ func TestGetFactor(t *testing.T) {
 		scenario string
 		client   *Client
 		options  GetFactorOpts
-		expected EnrollResponse
+		expected AuthenticationFactor
 		err      bool
 	}{
 		{
@@ -32,7 +32,7 @@ func TestGetFactor(t *testing.T) {
 			options: GetFactorOpts{
 				AuthenticationFactorID: "auth_factor_test123",
 			},
-			expected: EnrollResponse{
+			expected: AuthenticationFactor{
 				ID:        "auth_factor_test123",
 				CreatedAt: "2022-02-17T22:39:26.616Z",
 				UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -98,8 +98,8 @@ func TestEnrollFactor(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetEnrollOpts
-		expected EnrollResponse
+		options  EnrollFactorOpts
+		expected AuthenticationFactor
 		err      bool
 	}{
 		{
@@ -112,12 +112,12 @@ func TestEnrollFactor(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: GetEnrollOpts{
+			options: EnrollFactorOpts{
 				Type:       "totp",
 				TotpIssuer: "WorkOS",
 				TotpUser:   "some_user",
 			},
-			expected: EnrollResponse{
+			expected: AuthenticationFactor{
 				ID:        "auth_factor_test123",
 				CreatedAt: "2022-02-17T22:39:26.616Z",
 				UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -129,11 +129,11 @@ func TestEnrollFactor(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: GetEnrollOpts{
+			options: EnrollFactorOpts{
 				Type:        "sms",
 				PhoneNumber: "0000000000",
 			},
-			expected: EnrollResponse{
+			expected: AuthenticationFactor{
 				ID:        "auth_factor_test123",
 				CreatedAt: "2022-02-17T22:39:26.616Z",
 				UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -174,7 +174,7 @@ func enrollFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(EnrollResponse{
+	body, err := json.Marshal(AuthenticationFactor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -194,7 +194,7 @@ func TestChallengeFactor(t *testing.T) {
 		scenario string
 		client   *Client
 		options  ChallengeOpts
-		expected ChallengeResponse
+		expected Challenge
 		err      bool
 	}{
 		{
@@ -210,7 +210,7 @@ func TestChallengeFactor(t *testing.T) {
 			options: ChallengeOpts{
 				AuthenticationFactorID: "auth_factor_id",
 			},
-			expected: ChallengeResponse{
+			expected: Challenge{
 				ID:                     "auth_challenge_test123",
 				CreatedAt:              "2022-02-17T22:39:26.616Z",
 				UpdatedAt:              "2022-02-17T22:39:26.616Z",
@@ -252,7 +252,7 @@ func challengeFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(ChallengeResponse{
+	body, err := json.Marshal(Challenge{
 		ID:                     "auth_challenge_test123",
 		CreatedAt:              "2022-02-17T22:39:26.616Z",
 		UpdatedAt:              "2022-02-17T22:39:26.616Z",
@@ -272,7 +272,7 @@ func TestVerifyChallenge(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  VerifyOpts
+		options  VerifyChallengeOpts
 		expected VerifyResponse
 		err      bool
 	}{
@@ -286,7 +286,7 @@ func TestVerifyChallenge(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: VerifyOpts{
+			options: VerifyChallengeOpts{
 				AuthenticationChallengeID: "auth_challenge_test123",
 				Code:                      "0000000",
 			},
@@ -323,7 +323,7 @@ func getFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := json.Marshal(EnrollResponse{
+	body, err := json.Marshal(AuthenticationFactor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
@@ -377,7 +377,7 @@ func TestVerifyChallengeError(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  VerifyOpts
+		options  VerifyChallengeOpts
 		expected VerificationResponseError
 		err      bool
 	}{
@@ -386,7 +386,7 @@ func TestVerifyChallengeError(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: VerifyOpts{
+			options: VerifyChallengeOpts{
 				AuthenticationChallengeID: "auth_challenge_test123",
 				Code:                      "0000000",
 			},

--- a/pkg/mfa/mfa.go
+++ b/pkg/mfa/mfa.go
@@ -19,8 +19,8 @@ func SetAPIKey(apiKey string) {
 // EnrollFactor creates a MFA authorization factor.
 func EnrollFactor(
 	ctx context.Context,
-	opts GetEnrollOpts,
-) (EnrollResponse, error) {
+	opts EnrollFactorOpts,
+) (AuthenticationFactor, error) {
 	return DefaultClient.EnrollFactor(ctx, opts)
 }
 
@@ -28,14 +28,14 @@ func EnrollFactor(
 func ChallengeFactor(
 	ctx context.Context,
 	opts ChallengeOpts,
-) (ChallengeResponse, error) {
+) (Challenge, error) {
 	return DefaultClient.ChallengeFactor(ctx, opts)
 }
 
 // VerifyChallenge verifies the one time password provided by the end-user.
 func VerifyChallenge(
 	ctx context.Context,
-	opts VerifyOpts,
+	opts VerifyChallengeOpts,
 ) (VerifyResponse, error) {
 	return DefaultClient.VerifyChallenge(ctx, opts)
 }
@@ -43,7 +43,7 @@ func VerifyChallenge(
 // Deprecated: Use VerifyChallenge instead
 func VerifyFactor(
 	ctx context.Context,
-	opts VerifyOpts,
+	opts VerifyChallengeOpts,
 ) (interface{}, error) {
 	return DefaultClient.VerifyFactor(ctx, opts)
 }
@@ -60,6 +60,6 @@ func DeleteFactor(
 func GetFactor(
 	ctx context.Context,
 	opts GetFactorOpts,
-) (EnrollResponse, error) {
+) (AuthenticationFactor, error) {
 	return DefaultClient.GetFactor(ctx, opts)
 }

--- a/pkg/mfa/mfa.go
+++ b/pkg/mfa/mfa.go
@@ -36,7 +36,7 @@ func ChallengeFactor(
 func VerifyChallenge(
 	ctx context.Context,
 	opts VerifyChallengeOpts,
-) (VerifyResponse, error) {
+) (VerifyChallengeResponse, error) {
 	return DefaultClient.VerifyChallenge(ctx, opts)
 }
 

--- a/pkg/mfa/mfa.go
+++ b/pkg/mfa/mfa.go
@@ -20,7 +20,7 @@ func SetAPIKey(apiKey string) {
 func EnrollFactor(
 	ctx context.Context,
 	opts EnrollFactorOpts,
-) (AuthenticationFactor, error) {
+) (Factor, error) {
 	return DefaultClient.EnrollFactor(ctx, opts)
 }
 
@@ -60,6 +60,6 @@ func DeleteFactor(
 func GetFactor(
 	ctx context.Context,
 	opts GetFactorOpts,
-) (AuthenticationFactor, error) {
+) (Factor, error) {
 	return DefaultClient.GetFactor(ctx, opts)
 }

--- a/pkg/mfa/mfa_test.go
+++ b/pkg/mfa/mfa_test.go
@@ -19,20 +19,20 @@ func TestMfaEnrollFactors(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := AuthenticationFactor{
+	expectedResponse := Factor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
 		Type:      "generic_otp",
 	}
-	AuthenticationFactor, err := EnrollFactor(context.Background(), EnrollFactorOpts{
+	Factor, err := EnrollFactor(context.Background(), EnrollFactorOpts{
 		Type:       "totp",
 		TOTPIssuer: "WorkOS",
 		TOTPUser:   "some_user",
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, AuthenticationFactor)
+	require.Equal(t, expectedResponse, Factor)
 }
 
 func TestMfaChallengeFactors(t *testing.T) {
@@ -46,14 +46,14 @@ func TestMfaChallengeFactors(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := Challenge{
-		ID:                     "auth_challenge_test123",
-		CreatedAt:              "2022-02-17T22:39:26.616Z",
-		UpdatedAt:              "2022-02-17T22:39:26.616Z",
-		AuthenticationFactorID: "auth_factor_test123",
-		ExpiresAt:              "2022-02-17T22:39:26.616Z",
+		ID:        "auth_challenge_test123",
+		CreatedAt: "2022-02-17T22:39:26.616Z",
+		UpdatedAt: "2022-02-17T22:39:26.616Z",
+		FactorID:  "auth_factor_test123",
+		ExpiresAt: "2022-02-17T22:39:26.616Z",
 	}
 	Challenge, err := ChallengeFactor(context.Background(), ChallengeOpts{
-		AuthenticationFactorID: "auth_factor_id",
+		FactorID: "auth_factor_id",
 	})
 
 	require.NoError(t, err)
@@ -92,14 +92,14 @@ func TestGetFactors(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := AuthenticationFactor{
+	expectedResponse := Factor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
 		Type:      "generic_otp",
 	}
 	factorResponse, err := GetFactor(context.Background(), GetFactorOpts{
-		AuthenticationFactorID: "auth_factor_test123",
+		FactorID: "auth_factor_test123",
 	})
 
 	require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestDeleteFactors(t *testing.T) {
 	err := DeleteFactor(
 		context.Background(),
 		DeleteFactorOpts{
-			AuthenticationFactorID: "auth_factor_test1231",
+			FactorID: "auth_factor_test1231",
 		},
 	)
 

--- a/pkg/mfa/mfa_test.go
+++ b/pkg/mfa/mfa_test.go
@@ -25,14 +25,14 @@ func TestMfaEnrollFactors(t *testing.T) {
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
 		Type:      "generic_otp",
 	}
-	Factor, err := EnrollFactor(context.Background(), EnrollFactorOpts{
+	factor, err := EnrollFactor(context.Background(), EnrollFactorOpts{
 		Type:       "totp",
 		TOTPIssuer: "WorkOS",
 		TOTPUser:   "some_user",
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, Factor)
+	require.Equal(t, expectedResponse, factor)
 }
 
 func TestMfaChallengeFactors(t *testing.T) {
@@ -52,12 +52,12 @@ func TestMfaChallengeFactors(t *testing.T) {
 		FactorID:  "auth_factor_test123",
 		ExpiresAt: "2022-02-17T22:39:26.616Z",
 	}
-	Challenge, err := ChallengeFactor(context.Background(), ChallengeOpts{
+	challenge, err := ChallengeFactor(context.Background(), ChallengeOpts{
 		FactorID: "auth_factor_id",
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, Challenge)
+	require.Equal(t, expectedResponse, challenge)
 }
 
 func TestVerifyChallenges(t *testing.T) {
@@ -73,13 +73,13 @@ func TestVerifyChallenges(t *testing.T) {
 	expectedResponse := VerifyChallengeResponse{
 		Valid: true,
 	}
-	VerifyChallengeResponse, err := VerifyChallenge(context.Background(), VerifyChallengeOpts{
+	verifyChallengeResponse, err := VerifyChallenge(context.Background(), VerifyChallengeOpts{
 		AuthenticationChallengeID: "auth_challenge_test123",
 		Code:                      "0000000",
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, VerifyChallengeResponse)
+	require.Equal(t, expectedResponse, verifyChallengeResponse)
 }
 
 func TestGetFactors(t *testing.T) {

--- a/pkg/mfa/mfa_test.go
+++ b/pkg/mfa/mfa_test.go
@@ -27,8 +27,8 @@ func TestMfaEnrollFactors(t *testing.T) {
 	}
 	AuthenticationFactor, err := EnrollFactor(context.Background(), EnrollFactorOpts{
 		Type:       "totp",
-		TotpIssuer: "WorkOS",
-		TotpUser:   "some_user",
+		TOTPIssuer: "WorkOS",
+		TOTPUser:   "some_user",
 	})
 
 	require.NoError(t, err)

--- a/pkg/mfa/mfa_test.go
+++ b/pkg/mfa/mfa_test.go
@@ -70,16 +70,16 @@ func TestVerifyChallenges(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := VerifyResponse{
+	expectedResponse := VerifyChallengeResponse{
 		Valid: true,
 	}
-	verifyResponse, err := VerifyChallenge(context.Background(), VerifyChallengeOpts{
+	VerifyChallengeResponse, err := VerifyChallenge(context.Background(), VerifyChallengeOpts{
 		AuthenticationChallengeID: "auth_challenge_test123",
 		Code:                      "0000000",
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, verifyResponse)
+	require.Equal(t, expectedResponse, VerifyChallengeResponse)
 }
 
 func TestGetFactors(t *testing.T) {

--- a/pkg/mfa/mfa_test.go
+++ b/pkg/mfa/mfa_test.go
@@ -19,20 +19,20 @@ func TestMfaEnrollFactors(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := EnrollResponse{
+	expectedResponse := AuthenticationFactor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",
 		Type:      "generic_otp",
 	}
-	enrollResponse, err := EnrollFactor(context.Background(), GetEnrollOpts{
+	AuthenticationFactor, err := EnrollFactor(context.Background(), EnrollFactorOpts{
 		Type:       "totp",
 		TotpIssuer: "WorkOS",
 		TotpUser:   "some_user",
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, enrollResponse)
+	require.Equal(t, expectedResponse, AuthenticationFactor)
 }
 
 func TestMfaChallengeFactors(t *testing.T) {
@@ -45,19 +45,19 @@ func TestMfaChallengeFactors(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := ChallengeResponse{
+	expectedResponse := Challenge{
 		ID:                     "auth_challenge_test123",
 		CreatedAt:              "2022-02-17T22:39:26.616Z",
 		UpdatedAt:              "2022-02-17T22:39:26.616Z",
 		AuthenticationFactorID: "auth_factor_test123",
 		ExpiresAt:              "2022-02-17T22:39:26.616Z",
 	}
-	challengeResponse, err := ChallengeFactor(context.Background(), ChallengeOpts{
+	Challenge, err := ChallengeFactor(context.Background(), ChallengeOpts{
 		AuthenticationFactorID: "auth_factor_id",
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, challengeResponse)
+	require.Equal(t, expectedResponse, Challenge)
 }
 
 func TestVerifyChallenges(t *testing.T) {
@@ -73,7 +73,7 @@ func TestVerifyChallenges(t *testing.T) {
 	expectedResponse := VerifyResponse{
 		Valid: true,
 	}
-	verifyResponse, err := VerifyChallenge(context.Background(), VerifyOpts{
+	verifyResponse, err := VerifyChallenge(context.Background(), VerifyChallengeOpts{
 		AuthenticationChallengeID: "auth_challenge_test123",
 		Code:                      "0000000",
 	})
@@ -92,7 +92,7 @@ func TestGetFactors(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := EnrollResponse{
+	expectedResponse := AuthenticationFactor{
 		ID:        "auth_factor_test123",
 		CreatedAt: "2022-02-17T22:39:26.616Z",
 		UpdatedAt: "2022-02-17T22:39:26.616Z",


### PR DESCRIPTION
- `EnrollResponse` updated to `Factor`

- `ChallengeResponse ` updated to `Challenge`

- `GetEnrollOpts`  updated to `EnrollFactorOpts`

- `VerifyOpts`  updated to `VerifyChallengeOpts`

- capitalized `AuthenticationFactor` fields to `SMS` and `TOTP`

- created type `FactorType` with `SMS` and `TOTP` enums & updated `Factor` and `EnrollFactorOpts` accordingly

- made `TOTPDetails` and `SMSDetails` structs 

- changed `VerifyResponse` to be named `VerifyChallengeResponse`