### PR TITLE
Improve SSO and Passwordless naming consistency

### DIFF
--- a/pkg/passwordless/client.go
+++ b/pkg/passwordless/client.go
@@ -141,7 +141,7 @@ func (c *Client) CreateSession(ctx context.Context, opts CreateSessionOpts) (Pas
 // SendSessionOpts contains the options to send a Passwordless Session via email.
 type SendSessionOpts struct {
 	// Passwordless Session unique identifier.
-	ID string
+	SessionID string
 }
 
 // SendSession sends a Passwordless Session via email
@@ -159,7 +159,7 @@ func (c *Client) SendSession(
 	endpoint := fmt.Sprintf(
 		"%s/passwordless/sessions/%s/send",
 		c.Endpoint,
-		opts.ID,
+		opts.SessionID,
 	)
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(data))
 	if err != nil {

--- a/pkg/passwordless/client_test.go
+++ b/pkg/passwordless/client_test.go
@@ -114,7 +114,7 @@ func TestSendSession(t *testing.T) {
 				APIKey: "test",
 			},
 			options: SendSessionOpts{
-				ID: "session_id",
+				SessionID: "session_id",
 			},
 		},
 	}

--- a/pkg/passwordless/passwordless_test.go
+++ b/pkg/passwordless/passwordless_test.go
@@ -47,7 +47,7 @@ func TestPasswordlessSendSession(t *testing.T) {
 	SetAPIKey("test")
 
 	err := SendSession(context.Background(), SendSessionOpts{
-		ID: "session_id",
+		SessionID: "session_id",
 	})
 	require.NoError(t, err)
 }

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -111,7 +111,7 @@ func (c *Client) init() {
 
 // GetLoginHandler returns an http.Handler that redirects client to the appropriate
 // login provider.
-func (c *Client) GetLoginHandler(opts GetAuthorizationURLOptions) http.Handler {
+func (c *Client) GetLoginHandler(opts GetAuthorizationURLOpts) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		u, err := c.GetAuthorizationURL(opts)
 		if err != nil {
@@ -124,9 +124,9 @@ func (c *Client) GetLoginHandler(opts GetAuthorizationURLOptions) http.Handler {
 	})
 }
 
-// GetAuthorizationURLOptions contains the options to pass in order to generate
+// GetAuthorizationURLOpts contains the options to pass in order to generate
 // an authorization url.
-type GetAuthorizationURLOptions struct {
+type GetAuthorizationURLOpts struct {
 	// Deprecated: Please use `Organization` parameter instead.
 	// The app/company domain without without protocol (eg. example.com).
 	Domain string
@@ -164,7 +164,7 @@ type GetAuthorizationURLOptions struct {
 
 // GetAuthorizationURL returns an authorization url generated with the given
 // options.
-func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL, error) {
+func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOpts) (*url.URL, error) {
 	c.once.Do(c.init)
 
 	redirectURI := opts.RedirectURI
@@ -211,8 +211,8 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL,
 	return u, nil
 }
 
-// GetProfileAndTokenOptions contains the options to pass in order to get a user profile and access token.
-type GetProfileAndTokenOptions struct {
+// GetProfileAndTokenOpts contains the options to pass in order to get a user profile and access token.
+type GetProfileAndTokenOpts struct {
 	// An opaque string provided by the authorization server. It will be
 	// exchanged for an Access Token when the user’s profile is sent.
 	Code string
@@ -258,7 +258,7 @@ type ProfileAndToken struct {
 
 // GetProfileAndToken returns a profile describing the user that authenticated with
 // WorkOS SSO.
-func (c *Client) GetProfileAndToken(ctx context.Context, opts GetProfileAndTokenOptions) (ProfileAndToken, error) {
+func (c *Client) GetProfileAndToken(ctx context.Context, opts GetProfileAndTokenOpts) (ProfileAndToken, error) {
 	c.once.Do(c.init)
 
 	form := make(url.Values, 5)
@@ -298,7 +298,7 @@ func (c *Client) GetProfileAndToken(ctx context.Context, opts GetProfileAndToken
 }
 
 // GetProfile contains the options to pass in order to get a user profile.
-type GetProfileOptions struct {
+type GetProfileOpts struct {
 	// An opaque string provided by the authorization server. It will be
 	// exchanged for an Access Token when the user’s profile is sent.
 	AccessToken string
@@ -306,7 +306,7 @@ type GetProfileOptions struct {
 
 // GetProfile returns a profile describing the user that authenticated with
 // WorkOS SSO.
-func (c *Client) GetProfile(ctx context.Context, opts GetProfileOptions) (Profile, error) {
+func (c *Client) GetProfile(ctx context.Context, opts GetProfileOpts) (Profile, error) {
 	c.once.Do(c.init)
 
 	req, err := http.NewRequest(

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -16,12 +16,12 @@ import (
 func TestClientAuthorizeURL(t *testing.T) {
 	tests := []struct {
 		scenario string
-		options  GetAuthorizationURLOptions
+		options  GetAuthorizationURLOpts
 		expected string
 	}{
 		{
 			scenario: "generate url",
-			options: GetAuthorizationURLOptions{
+			options: GetAuthorizationURLOpts{
 				Domain:      "lyft.com",
 				RedirectURI: "https://example.com/sso/workos/callback",
 			},
@@ -29,7 +29,7 @@ func TestClientAuthorizeURL(t *testing.T) {
 		},
 		{
 			scenario: "generate url with state",
-			options: GetAuthorizationURLOptions{
+			options: GetAuthorizationURLOpts{
 				Domain:      "lyft.com",
 				RedirectURI: "https://example.com/sso/workos/callback",
 				State:       "custom state",
@@ -38,7 +38,7 @@ func TestClientAuthorizeURL(t *testing.T) {
 		},
 		{
 			scenario: "generate url with provider",
-			options: GetAuthorizationURLOptions{
+			options: GetAuthorizationURLOpts{
 				Provider:    "GoogleOAuth",
 				RedirectURI: "https://example.com/sso/workos/callback",
 				State:       "custom state",
@@ -47,7 +47,7 @@ func TestClientAuthorizeURL(t *testing.T) {
 		},
 		{
 			scenario: "generate url with connection",
-			options: GetAuthorizationURLOptions{
+			options: GetAuthorizationURLOpts{
 				Connection:  "connection_123",
 				RedirectURI: "https://example.com/sso/workos/callback",
 				State:       "custom state",
@@ -56,7 +56,7 @@ func TestClientAuthorizeURL(t *testing.T) {
 		},
 		{
 			scenario: "generate url with provider and domain",
-			options: GetAuthorizationURLOptions{
+			options: GetAuthorizationURLOpts{
 				Domain:      "lyft.com",
 				Provider:    "GoogleOAuth",
 				RedirectURI: "https://example.com/sso/workos/callback",
@@ -66,7 +66,7 @@ func TestClientAuthorizeURL(t *testing.T) {
 		},
 		{
 			scenario: "generate url with organization",
-			options: GetAuthorizationURLOptions{
+			options: GetAuthorizationURLOpts{
 				Organization: "organization_123",
 				RedirectURI:  "https://example.com/sso/workos/callback",
 				State:        "custom state",
@@ -75,7 +75,7 @@ func TestClientAuthorizeURL(t *testing.T) {
 		},
 		{
 			scenario: "generate url with DomainHint",
-			options: GetAuthorizationURLOptions{
+			options: GetAuthorizationURLOpts{
 				Connection:  "connection_123",
 				RedirectURI: "https://example.com/sso/workos/callback",
 				State:       "custom state",
@@ -85,7 +85,7 @@ func TestClientAuthorizeURL(t *testing.T) {
 		},
 		{
 			scenario: "generate url with LoginHint",
-			options: GetAuthorizationURLOptions{
+			options: GetAuthorizationURLOpts{
 				Connection:  "connection_123",
 				RedirectURI: "https://example.com/sso/workos/callback",
 				State:       "custom state",
@@ -115,7 +115,7 @@ func TestClientAuthorizeURLWithNoConnectionDomainAndProvider(t *testing.T) {
 		ClientID: "client_123",
 	}
 
-	u, err := client.GetAuthorizationURL(GetAuthorizationURLOptions{
+	u, err := client.GetAuthorizationURL(GetAuthorizationURLOpts{
 		RedirectURI: "https://example.com/sso/workos/callback",
 		State:       "state",
 	})
@@ -128,7 +128,7 @@ func TestClientGetProfileAndToken(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetProfileAndTokenOptions
+		options  GetProfileAndTokenOpts
 		expected Profile
 		err      bool
 	}{
@@ -143,7 +143,7 @@ func TestClientGetProfileAndToken(t *testing.T) {
 				APIKey:   "test",
 				ClientID: "client_123",
 			},
-			options: GetProfileAndTokenOptions{
+			options: GetProfileAndTokenOpts{
 				Code: "authorization_code",
 			},
 			expected: Profile{
@@ -237,7 +237,7 @@ func TestClientGetProfile(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetProfileOptions
+		options  GetProfileOpts
 		expected Profile
 		err      bool
 	}{
@@ -247,7 +247,7 @@ func TestClientGetProfile(t *testing.T) {
 				APIKey:   "test",
 				ClientID: "client_123",
 			},
-			options: GetProfileOptions{
+			options: GetProfileOpts{
 				AccessToken: "access_token",
 			},
 			expected: Profile{

--- a/pkg/sso/sso.go
+++ b/pkg/sso/sso.go
@@ -23,25 +23,25 @@ func Configure(apiKey, clientID string) {
 
 // GetAuthorizationURL returns an authorization url generated with the given
 // options.
-func GetAuthorizationURL(opts GetAuthorizationURLOptions) (*url.URL, error) {
+func GetAuthorizationURL(opts GetAuthorizationURLOpts) (*url.URL, error) {
 	return DefaultClient.GetAuthorizationURL(opts)
 }
 
 // GetProfileAndToken returns a profile describing the user that authenticated with
 // WorkOS SSO.
-func GetProfileAndToken(ctx context.Context, opts GetProfileAndTokenOptions) (ProfileAndToken, error) {
+func GetProfileAndToken(ctx context.Context, opts GetProfileAndTokenOpts) (ProfileAndToken, error) {
 	return DefaultClient.GetProfileAndToken(ctx, opts)
 }
 
 // GetProfile returns a profile describing the user that authenticated with
 // WorkOS SSO.
-func GetProfile(ctx context.Context, opts GetProfileOptions) (Profile, error) {
+func GetProfile(ctx context.Context, opts GetProfileOpts) (Profile, error) {
 	return DefaultClient.GetProfile(ctx, opts)
 }
 
 // Login returns a http.Handler that redirects client to the appropriate
 // login provider.
-func Login(opts GetAuthorizationURLOptions) http.Handler {
+func Login(opts GetAuthorizationURLOpts) http.Handler {
 	return DefaultClient.GetLoginHandler(opts)
 }
 

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -45,7 +45,7 @@ func TestLogin(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
-	mux.Handle("/login", Login(GetAuthorizationURLOptions{
+	mux.Handle("/login", Login(GetAuthorizationURLOpts{
 		Domain:      "lyft.com",
 		RedirectURI: redirectURI,
 	}))
@@ -64,7 +64,7 @@ func TestLogin(t *testing.T) {
 	})
 
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		p, err := GetProfileAndToken(context.Background(), GetProfileAndTokenOptions{
+		p, err := GetProfileAndToken(context.Background(), GetProfileAndTokenOpts{
 			Code: "authorization_code",
 		})
 		if err != nil {
@@ -172,7 +172,7 @@ func TestSsoGetProfile(t *testing.T) {
 			"last_name":  "bar",
 		},
 	}
-	profileResponse, err := GetProfile(context.Background(), GetProfileOptions{
+	profileResponse, err := GetProfile(context.Background(), GetProfileOpts{
 		AccessToken: "access_token",
 	})
 


### PR DESCRIPTION
SSO
- `GetProfileOptions` → `GetProfileOpts` 
- `GetProfileAndTokenOptions` → `GetProfileAndTokenOpts`
- `GetAuthorizationURLOptions` → `GetAuthorizationURLOpts`

Passwordless
- `passwordless.SendSessionOpts.ID` → `passwordless.SendSessionOpts.SessionID`