### PR TITLE
Create a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+## Documentation
+
+Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.
+
+```
+[ ] Yes
+```
+
+If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.


### PR DESCRIPTION
Setting up a PR template reminding to update the docs so that:
- We don't forget to update the docs when the developer API changes
- If needed, the DX team can provide feedback on creating a coherent API across other WorkOS SDKs