### PR TITLE
remove deprecated function and parameters

### DIFF
--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -275,11 +275,6 @@ func (c *Client) ChallengeFactor(
 
 }
 
-// Deprecated: Use VerifyChallenge instead.
-func (c *Client) VerifyFactor(ctx context.Context, opts VerifyChallengeOpts) (interface{}, error) {
-	return c.VerifyChallenge(ctx, opts)
-}
-
 type VerificationResponseError struct {
 	Code    string
 	Message string

--- a/pkg/mfa/mfa.go
+++ b/pkg/mfa/mfa.go
@@ -40,14 +40,6 @@ func VerifyChallenge(
 	return DefaultClient.VerifyChallenge(ctx, opts)
 }
 
-// Deprecated: Use VerifyChallenge instead
-func VerifyFactor(
-	ctx context.Context,
-	opts VerifyChallengeOpts,
-) (interface{}, error) {
-	return DefaultClient.VerifyFactor(ctx, opts)
-}
-
 // DeleteFactor deletes a factor by ID.
 func DeleteFactor(
 	ctx context.Context,

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -3,7 +3,6 @@ package sso
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -127,9 +126,6 @@ func (c *Client) GetLoginHandler(opts GetAuthorizationURLOpts) http.Handler {
 // GetAuthorizationURLOpts contains the options to pass in order to generate
 // an authorization url.
 type GetAuthorizationURLOpts struct {
-	// Deprecated: Please use `Organization` parameter instead.
-	// The app/company domain without without protocol (eg. example.com).
-	Domain string
 
 	// Domain hint that will be passed as a parameter to the IdP login page.
 	// OPTIONAL.
@@ -173,16 +169,8 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOpts) (*url.URL, er
 	query.Set("client_id", c.ClientID)
 	query.Set("redirect_uri", redirectURI)
 	query.Set("response_type", "code")
-
-	if opts.Domain == "" && opts.Provider == "" && opts.Connection == "" && opts.Organization == "" {
-		return nil, errors.New("incomplete arguments: missing connection, organization, domain, or provider")
-	}
 	if opts.Provider != "" {
 		query.Set("provider", string(opts.Provider))
-	}
-	if opts.Domain != "" {
-		query.Set("domain", opts.Domain)
-		fmt.Println("The `domain` parameter for `getAuthorizationURL` is deprecated. Please use `organization` instead.")
 	}
 	if opts.DomainHint != "" {
 		query.Set("domain_hint", opts.DomainHint)
@@ -347,17 +335,6 @@ type ConnectionDomain struct {
 	Domain string `json:"domain"`
 }
 
-// ConnectionStatus represents a Connection's linked status.
-//
-// Deprecated: Please use ConnectionState instead.
-type ConnectionStatus string
-
-// Constants that enumerate the available Connection's linked statuses.
-const (
-	Linked   ConnectionStatus = "linked"
-	Unlinked ConnectionStatus = "unlinked"
-)
-
 // ConnectionState indicates whether a Connection is able to authenticate users.
 type ConnectionState string
 
@@ -372,9 +349,6 @@ const (
 type Connection struct {
 	// Connection unique identifier.
 	ID string `json:"id"`
-
-	// Connection linked status. Deprecated; use State instead.
-	Status ConnectionStatus `json:"status"`
 
 	// Connection linked state.
 	State ConnectionState `json:"state"`

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -22,19 +22,17 @@ func TestClientAuthorizeURL(t *testing.T) {
 		{
 			scenario: "generate url",
 			options: GetAuthorizationURLOpts{
-				Domain:      "lyft.com",
 				RedirectURI: "https://example.com/sso/workos/callback",
 			},
-			expected: "https://api.workos.com/sso/authorize?client_id=client_123&domain=lyft.com&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code",
+			expected: "https://api.workos.com/sso/authorize?client_id=client_123&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code",
 		},
 		{
 			scenario: "generate url with state",
 			options: GetAuthorizationURLOpts{
-				Domain:      "lyft.com",
 				RedirectURI: "https://example.com/sso/workos/callback",
 				State:       "custom state",
 			},
-			expected: "https://api.workos.com/sso/authorize?client_id=client_123&domain=lyft.com&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
+			expected: "https://api.workos.com/sso/authorize?client_id=client_123&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
 		},
 		{
 			scenario: "generate url with provider",
@@ -55,16 +53,6 @@ func TestClientAuthorizeURL(t *testing.T) {
 			expected: "https://api.workos.com/sso/authorize?client_id=client_123&connection=connection_123&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
 		},
 		{
-			scenario: "generate url with provider and domain",
-			options: GetAuthorizationURLOpts{
-				Domain:      "lyft.com",
-				Provider:    "GoogleOAuth",
-				RedirectURI: "https://example.com/sso/workos/callback",
-				State:       "custom state",
-			},
-			expected: "https://api.workos.com/sso/authorize?client_id=client_123&domain=lyft.com&provider=GoogleOAuth&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
-		},
-		{
 			scenario: "generate url with organization",
 			options: GetAuthorizationURLOpts{
 				Organization: "organization_123",
@@ -72,16 +60,6 @@ func TestClientAuthorizeURL(t *testing.T) {
 				State:        "custom state",
 			},
 			expected: "https://api.workos.com/sso/authorize?client_id=client_123&organization=organization_123&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
-		},
-		{
-			scenario: "generate url with DomainHint",
-			options: GetAuthorizationURLOpts{
-				Connection:  "connection_123",
-				RedirectURI: "https://example.com/sso/workos/callback",
-				State:       "custom state",
-				DomainHint:  "foo.com",
-			},
-			expected: "https://api.workos.com/sso/authorize?client_id=client_123&connection=connection_123&domain_hint=foo.com&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
 		},
 		{
 			scenario: "generate url with LoginHint",
@@ -107,21 +85,6 @@ func TestClientAuthorizeURL(t *testing.T) {
 			require.Equal(t, test.expected, u.String())
 		})
 	}
-}
-
-func TestClientAuthorizeURLWithNoConnectionDomainAndProvider(t *testing.T) {
-	client := Client{
-		APIKey:   "test",
-		ClientID: "client_123",
-	}
-
-	u, err := client.GetAuthorizationURL(GetAuthorizationURLOpts{
-		RedirectURI: "https://example.com/sso/workos/callback",
-		State:       "state",
-	})
-
-	require.Error(t, err)
-	require.Nil(t, u)
 }
 
 func TestClientGetProfileAndToken(t *testing.T) {
@@ -352,7 +315,6 @@ func TestGetConnection(t *testing.T) {
 				ID:             "conn_id",
 				ConnectionType: "GoogleOAuth",
 				State:          Active,
-				Status:         Linked,
 				Name:           "Foo Corp",
 			},
 		},
@@ -389,7 +351,6 @@ func getConnectionTestHandler(w http.ResponseWriter, r *http.Request) {
 		ID:             "conn_id",
 		ConnectionType: "GoogleOAuth",
 		State:          Active,
-		Status:         Linked,
 		Name:           "Foo Corp",
 	})
 	if err != nil {
@@ -426,7 +387,6 @@ func TestListConnections(t *testing.T) {
 						ID:             "conn_id",
 						ConnectionType: "GoogleOAuth",
 						State:          Active,
-						Status:         Linked,
 						Name:           "Foo Corp",
 					},
 				},
@@ -476,7 +436,6 @@ func listConnectionsTestHandler(w http.ResponseWriter, r *http.Request) {
 				ID:             "conn_id",
 				ConnectionType: "GoogleOAuth",
 				State:          Active,
-				Status:         Linked,
 				Name:           "Foo Corp",
 			},
 		},

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -46,7 +46,6 @@ func TestLogin(t *testing.T) {
 	wg.Add(1)
 
 	mux.Handle("/login", Login(GetAuthorizationURLOpts{
-		Domain:      "lyft.com",
 		RedirectURI: redirectURI,
 	}))
 
@@ -102,7 +101,6 @@ func TestSsoGetConnection(t *testing.T) {
 		ID:             "conn_id",
 		ConnectionType: "GoogleOAuth",
 		State:          Active,
-		Status:         Linked,
 		Name:           "Foo Corp",
 	}
 	connectionResponse, err := GetConnection(context.Background(), GetConnectionOpts{
@@ -129,7 +127,6 @@ func TestSsoListConnections(t *testing.T) {
 				ID:             "conn_id",
 				ConnectionType: "GoogleOAuth",
 				State:          Active,
-				Status:         Linked,
 				Name:           "Foo Corp",
 			},
 		},


### PR DESCRIPTION
## Description

Removes deprecated function `VerifyFactor` as well as deprecated parameters `Domain` and `ConnectionStatus`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
