### PR TITLE
Update module paths to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WorkOS Go Library
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/workos/workos-go.svg)](https://pkg.go.dev/github.com/workos/workos-go)
+[![Go Reference](https://pkg.go.dev/badge/github.com/workos/workos-go/v2.svg)](https://pkg.go.dev/github.com/workos/workos-go/v2)
 
 The WorkOS library for Go provides convenient access to the WorkOS API from applications written in Go.
 
@@ -13,7 +13,7 @@ See the [API Reference](https://workos.com/docs/reference/client-libraries) for 
 Install the package with:
 
 ```
-go get -u github.com/workos/workos-go/...
+go get -u github.com/workos/workos-go/v2...
 ```
 
 ## Configuration

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/workos/workos-go
+module github.com/workos/workos-go/v2
 
 go 1.13
 

--- a/pkg/auditlogs/README.md
+++ b/pkg/auditlogs/README.md
@@ -1,13 +1,13 @@
 # auditlogs
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/pkg/auditlogs)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v2/pkg/auditlogs)
 
 A Go package to send audit log events to WorkOS.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/pkg/auditlogs
+go get -u github.com/workos/workos-go/v2/pkg/auditlogs
 ```
 
 ## How it works
@@ -15,7 +15,7 @@ go get -u github.com/workos/workos-go/pkg/auditlogs
 ```go
 package main
 
-import "github.com/workos/workos-go/pkg/auditlogs"
+import "github.com/workos/workos-go/v2/pkg/auditlogs"
 
 func main() {
 	auditlogs.SetAPIKey("my_api_key")

--- a/pkg/auditlogs/client.go
+++ b/pkg/auditlogs/client.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/pkg/workos_errors"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
 
-	"github.com/workos/workos-go/internal/workos"
+	"github.com/workos/workos-go/v2/internal/workos"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/auditlogs/client_test.go
+++ b/pkg/auditlogs/client_test.go
@@ -3,7 +3,7 @@ package auditlogs
 import (
 	"context"
 	"encoding/json"
-	"github.com/workos/workos-go/pkg/workos_errors"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"

--- a/pkg/audittrail/README.md
+++ b/pkg/audittrail/README.md
@@ -1,13 +1,13 @@
 # audittrail
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/pkg/audittrail)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v2/pkg/audittrail)
 
 A Go package to send audit trails events to WorkOS.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/pkg/audittrail
+go get -u github.com/workos/workos-go/v2/pkg/audittrail
 ```
 
 ## How it works
@@ -15,7 +15,7 @@ go get -u github.com/workos/workos-go/pkg/audittrail
 ```go
 package main
 
-import "github.com/workos/workos-go/pkg/audittrail"
+import "github.com/workos/workos-go/v2/pkg/audittrail"
 
 func main() {
     audittrail.SetAPIKey("my_api_key")

--- a/pkg/audittrail/audittrail_test.go
+++ b/pkg/audittrail/audittrail_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 func TestAuditTrail(t *testing.T) {

--- a/pkg/audittrail/client.go
+++ b/pkg/audittrail/client.go
@@ -9,12 +9,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/pkg/workos_errors"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
 
 	"github.com/google/go-querystring/query"
 
-	"github.com/workos/workos-go/internal/workos"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/internal/workos"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/audittrail/client_test.go
+++ b/pkg/audittrail/client_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 func TestClientPublish(t *testing.T) {

--- a/pkg/directorysync/README.md
+++ b/pkg/directorysync/README.md
@@ -1,13 +1,13 @@
 # directorysync
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/pkg/directorysync)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v2/pkg/directorysync)
 
 A Go package to make requests to the WorkOS Directory Sync API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/pkg/directorysync
+go get -u github.com/workos/workos-go/v2/pkg/directorysync
 ```
 
 ## How it works

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/pkg/workos_errors"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
 
-	"github.com/workos/workos-go/internal/workos"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/internal/workos"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 func TestListUsers(t *testing.T) {

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 func TestDirectorySyncListUsers(t *testing.T) {

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/pkg/workos_errors"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
 
-	"github.com/workos/workos-go/internal/workos"
+	"github.com/workos/workos-go/v2/internal/workos"
 )
 
 // This represents the list of errors that could be raised when using the mfa package

--- a/pkg/organizations/README.md
+++ b/pkg/organizations/README.md
@@ -1,13 +1,13 @@
 # organizations
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/pkg/organizations)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v2/pkg/organizations)
 
 A Go package to make requests to the WorkOS Organizations API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/pkg/organizations
+go get -u github.com/workos/workos-go/v2/pkg/organizations
 ```
 
 ## How it works

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -9,11 +9,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/pkg/workos_errors"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/internal/workos"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/internal/workos"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 func TestGetOrganization(t *testing.T) {

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 func TestOrganizationsGetOrganization(t *testing.T) {

--- a/pkg/passwordless/README.md
+++ b/pkg/passwordless/README.md
@@ -1,13 +1,13 @@
 # passwordless
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/pkg/passwordless)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v2/pkg/passwordless)
 
 A Go package to make requests to the WorkOS Magic Link API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/pkg/passwordless
+go get -u github.com/workos/workos-go/v2/pkg/passwordless
 ```
 
 ## How it works

--- a/pkg/passwordless/client.go
+++ b/pkg/passwordless/client.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/pkg/workos_errors"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
 
-	"github.com/workos/workos-go/internal/workos"
+	"github.com/workos/workos-go/v2/internal/workos"
 )
 
 // Client represents a client that performs Passwordless requests to the WorkOS API.

--- a/pkg/portal/README.md
+++ b/pkg/portal/README.md
@@ -1,13 +1,13 @@
 # portal
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/pkg/portal)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v2/pkg/portal)
 
 A Go package to make requests to the WorkOS Admin Portal API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/pkg/portal
+go get -u github.com/workos/workos-go/v2/pkg/portal
 ```
 
 ## How it works

--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/pkg/workos_errors"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
 
-	"github.com/workos/workos-go/internal/workos"
+	"github.com/workos/workos-go/v2/internal/workos"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/sso/README.md
+++ b/pkg/sso/README.md
@@ -1,13 +1,13 @@
 # sso
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/pkg/sso)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v2/pkg/sso)
 
 A go package to request WorkOS SSO API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/pkg/sso
+go get -u github.com/workos/workos-go/v2/pkg/sso
 ```
 
 ## How it works

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -12,10 +12,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/pkg/workos_errors"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
 
-	"github.com/workos/workos-go/internal/workos"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/internal/workos"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 func TestClientAuthorizeURL(t *testing.T) {

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/common"
 )
 
 func TestLogin(t *testing.T) {

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	"github.com/workos/workos-go/pkg/webhooks"
+	"github.com/workos/workos-go/v2/pkg/webhooks"
 	"strconv"
 	"testing"
 	"time"

--- a/pkg/workos_errors/errors_test.go
+++ b/pkg/workos_errors/errors_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/workos/workos-go/pkg/workos_errors"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
 )
 
 func TestIsBadRequest(t *testing.T) {


### PR DESCRIPTION
## Description

Since we are introducing the v2 major version, we must follow [Go breaking change instructions](https://go.dev/blog/v2-go-modules) for v2 and beyond versions.

More details on this [thread](https://work-os.slack.com/archives/CG875BV3J/p1671642172066689).

After this is merged, I should create a new tag for `v2.0.1`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
