### PR TITLE
Add groups SSO user profile attribute

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -35,34 +35,38 @@ type ConnectionType string
 
 // Constants that enumerate the available connection types.
 const (
-	ADFSSAML          ConnectionType = "ADFSSAML"
-	AdpOidc           ConnectionType = "AdpOidc"
-	Auth0SAML         ConnectionType = "Auth0SAML"
-	AzureSAML         ConnectionType = "AzureSAML"
-	CasSAML           ConnectionType = "CasSAML"
-	CloudflareSAML    ConnectionType = "CloudflareSAML"
-	ClassLinkSAML     ConnectionType = "ClassLinkSAML"
-	CyberArkSAML      ConnectionType = "CyberArkSAML"
-	DuoSAML           ConnectionType = "DuoSAML"
-	GenericOIDC       ConnectionType = "GenericOIDC"
-	GenericSAML       ConnectionType = "GenericSAML"
-	GoogleOAuth       ConnectionType = "GoogleOAuth"
-	GoogleSAML        ConnectionType = "GoogleSAML"
-	JumpCloudSAML     ConnectionType = "JumpCloudSAML"
-	MagicLink         ConnectionType = "MagicLink"
-	MicrosoftOAuth    ConnectionType = "MicrosoftOAuth"
-	MiniOrangeSAML    ConnectionType = "MiniOrangeSAML"
-	NetIqSAML         ConnectionType = "NetIqSAML"
-	OktaSAML          ConnectionType = "OktaSAML"
-	OneLoginSAML      ConnectionType = "OneLoginSAML"
-	OracleSAML        ConnectionType = "OracleSAML"
-	PingFederateSAML  ConnectionType = "PingFederateSAML"
-	PingOneSAML       ConnectionType = "PingOneSAML"
-	RipplingSAML      ConnectionType = "RipplingSAML"
-	SalesforceSAML    ConnectionType = "SalesforceSAML"
-	ShibbolethSAML    ConnectionType = "ShibbolethSAML"
-	SimpleSamlPhpSAML ConnectionType = "SimpleSamlPhpSAML"
-	VMwareSAML        ConnectionType = "VMwareSAML"
+	ADFSSAML              ConnectionType = "ADFSSAML"
+	AdpOidc               ConnectionType = "AdpOidc"
+	Auth0SAML             ConnectionType = "Auth0SAML"
+	AzureSAML             ConnectionType = "AzureSAML"
+	CasSAML               ConnectionType = "CasSAML"
+	CloudflareSAML        ConnectionType = "CloudflareSAML"
+	ClassLinkSAML         ConnectionType = "ClassLinkSAML"
+	CyberArkSAML          ConnectionType = "CyberArkSAML"
+	DuoSAML               ConnectionType = "DuoSAML"
+	GenericOIDC           ConnectionType = "GenericOIDC"
+	GenericSAML           ConnectionType = "GenericSAML"
+	GoogleOAuth           ConnectionType = "GoogleOAuth"
+	GoogleSAML            ConnectionType = "GoogleSAML"
+	JumpCloudSAML         ConnectionType = "JumpCloudSAML"
+	KeycloakSAML          ConnectionType = "KeycloakSAML"
+	LastPassSAML          ConnectionType = "LastPassSAML"
+	LoginGovOidc          ConnectionType = "LoginGovOidc"
+	MagicLink             ConnectionType = "MagicLink"
+	MicrosoftOAuth        ConnectionType = "MicrosoftOAuth"
+	MiniOrangeSAML        ConnectionType = "MiniOrangeSAML"
+	NetIqSAML             ConnectionType = "NetIqSAML"
+	OktaSAML              ConnectionType = "OktaSAML"
+	OneLoginSAML          ConnectionType = "OneLoginSAML"
+	OracleSAML            ConnectionType = "OracleSAML"
+	PingFederateSAML      ConnectionType = "PingFederateSAML"
+	PingOneSAML           ConnectionType = "PingOneSAML"
+	RipplingSAML          ConnectionType = "RipplingSAML"
+	SalesforceSAML        ConnectionType = "SalesforceSAML"
+	ShibbolethSAML        ConnectionType = "ShibbolethSAML"
+	ShibbolethGenericSAML ConnectionType = "ShibbolethGenericSAML"
+	SimpleSamlPhpSAML     ConnectionType = "SimpleSamlPhpSAML"
+	VMwareSAML            ConnectionType = "VMwareSAML"
 )
 
 // Client represents a client that fetch SSO data from WorkOS API.
@@ -243,6 +247,9 @@ type Profile struct {
 
 	// The user last name. Can be empty.
 	LastName string `json:"last_name"`
+
+	// The user's group memberships. Can be empty.
+	Groups []string `json:"groups"`
 
 	// The raw response of Profile attributes from the identity provider
 	RawAttributes map[string]interface{} `json:"raw_attributes"`

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -155,6 +155,7 @@ func TestClientGetProfileAndToken(t *testing.T) {
 				Email:          "foo@test.com",
 				FirstName:      "foo",
 				LastName:       "bar",
+				Groups:         []string{"Admins", "Developers"},
 				RawAttributes: map[string]interface{}{
 					"idp_id":     "123",
 					"email":      "foo@test.com",
@@ -216,6 +217,7 @@ func profileAndTokenTestHandler(w http.ResponseWriter, r *http.Request) {
 			Email:          "foo@test.com",
 			FirstName:      "foo",
 			LastName:       "bar",
+			Groups:         []string{"Admins", "Developers"},
 			RawAttributes: map[string]interface{}{
 				"idp_id":     "123",
 				"email":      "foo@test.com",
@@ -259,6 +261,7 @@ func TestClientGetProfile(t *testing.T) {
 				Email:          "foo@test.com",
 				FirstName:      "foo",
 				LastName:       "bar",
+				Groups:         []string{"Admins", "Developers"},
 				RawAttributes: map[string]interface{}{
 					"idp_id":     "123",
 					"email":      "foo@test.com",
@@ -310,6 +313,7 @@ func profileTestHandler(w http.ResponseWriter, r *http.Request) {
 		Email:          "foo@test.com",
 		FirstName:      "foo",
 		LastName:       "bar",
+		Groups:         []string{"Admins", "Developers"},
 		RawAttributes: map[string]interface{}{
 			"idp_id":     "123",
 			"email":      "foo@test.com",

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -34,6 +34,7 @@ func TestLogin(t *testing.T) {
 		Email:          "foo@test.com",
 		FirstName:      "foo",
 		LastName:       "bar",
+		Groups:         []string{"Admins", "Developers"},
 		RawAttributes: map[string]interface{}{
 			"idp_id":     "123",
 			"email":      "foo@test.com",
@@ -165,6 +166,7 @@ func TestSsoGetProfile(t *testing.T) {
 		Email:          "foo@test.com",
 		FirstName:      "foo",
 		LastName:       "bar",
+		Groups:         []string{"Admins", "Developers"},
 		RawAttributes: map[string]interface{}{
 			"idp_id":     "123",
 			"email":      "foo@test.com",


### PR DESCRIPTION
## Description

Adds optional `groups` attribute to user profile (currently available behind a feature flag).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
