### PR TITLE
Always return `code` or `error` in responses as `ErrorCode` when present

### DIFF
--- a/pkg/workos_errors/http.go
+++ b/pkg/workos_errors/http.go
@@ -72,15 +72,23 @@ func getJsonErrorMessage(b []byte, statusCode int) (string, string, []string, []
 		return string(b), "", nil, nil
 	}
 
-	if payload.Error != "" && payload.ErrorDescription != "" {
-		return fmt.Sprintf("%s %s", payload.Error, payload.ErrorDescription), "", nil, nil
-	} else if payload.Message != "" && len(payload.Errors) == 0 {
-		return payload.Message, "", nil, nil
-	} else if payload.Message != "" && len(payload.Errors) > 0 {
-		return payload.Message, payload.Code, payload.Errors, nil
+	var errorCode string
+
+	if payload.Code != "" {
+		errorCode = payload.Code
+	} else {
+		errorCode = payload.Error
 	}
 
-	return string(b), "", nil, nil
+	if payload.Error != "" && payload.ErrorDescription != "" {
+		return fmt.Sprintf("%s %s", payload.Error, payload.ErrorDescription), errorCode, nil, nil
+	} else if payload.Message != "" && len(payload.Errors) == 0 {
+		return payload.Message, errorCode, nil, nil
+	} else if payload.Message != "" && len(payload.Errors) > 0 {
+		return payload.Message, errorCode, payload.Errors, nil
+	}
+
+	return string(b), errorCode, nil, nil
 }
 
 // HTTPError represents an http error.


### PR DESCRIPTION
## Description

We currently set `ErrorCode` in `HTTPError` from the `code` field in raw responses from the WorkOS API, but only in certain cases, [like getting a `422`](https://github.com/workos/workos-go/blob/ec9e683bba39ec3b05abc7376c633929fc98376f/pkg/workos_errors/http.go#L47).

Otherwise, `ErrorCode` ends up as empty string in other cases. For example, as noted in #198, when an invalid Authorization Code is provided to the token endpoint, the following raw error is returned:

```json
{ 
  "error": "invalid_grant", 
  "error_description": "The code '01E2RJ4C05B52KKZ8FSRDAP23J' has expired or is invalid." 
}
```

However, the `ErrorCode` is not populated, making it hard to handle this (or other) particular errors.

This PR updates the error parsing logic to always attempt to populate `ErrorCode` with `code` from the response, falling back to `error` when not present. In all cases I'm aware of, `error` should be a discrete error type identifier suitable for dispatching on in response handling code.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
