### PR TITLE
Add ActorNames/ActorIds to CreateExportOpts

### DIFF
--- a/pkg/auditlogs/client.go
+++ b/pkg/auditlogs/client.go
@@ -130,8 +130,14 @@ type CreateExportOpts struct {
 	// Optional list of actions to filter
 	Actions []string `json:"actions,omitempty"`
 
-	// Optional list of actors to filter
+	// Deprecated - use `ActorNames` instead
 	Actors []string `json:"actors,omitempty"`
+
+	// Optional list of actor names to filter by
+	ActorNames []string `json:"actor_names,omitempty"`
+
+	// Optional list of actor ids to filter by
+	ActorIds []string `json:"actor_ids,omitempty"`
 
 	// Optional list of targets to filter
 	Targets []string `json:"targets,omitempty"`

--- a/pkg/auditlogs/client_test.go
+++ b/pkg/auditlogs/client_test.go
@@ -189,6 +189,8 @@ func TestCreateExports(t *testing.T) {
 			require.Equal(t, opts.Actions[0], "create-user")
 			require.Equal(t, opts.Targets[0], "user")
 			require.Equal(t, opts.Actors, []string{"Jon", "Smith"})
+			require.Equal(t, opts.ActorNames, []string{"Jon", "Smith"})
+			require.Equal(t, opts.ActorIds, []string{"user:1234"})
 
 			body, _ := json.Marshal(AuditLogExport{
 				ID: "test123",
@@ -210,6 +212,8 @@ func TestCreateExports(t *testing.T) {
 			Actions: []string{"create-user"},
 			Targets: []string{"user"},
 			Actors:  []string{"Jon", "Smith"},
+			ActorNames:  []string{"Jon", "Smith"},
+			ActorIds:  []string{"user:1234"},
 		})
 		require.Equal(t, body, AuditLogExport{
 			ID: "test123",


### PR DESCRIPTION
## Description

Adds the new `ActorIds` audit-log exports param (and deprecates `Actors` in favor of `ActorNames`)

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
