### PR TITLE
Add Events API beta

### DIFF
--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -1,0 +1,11 @@
+# events 
+
+A Go package to retrieve events from WorkOS.
+
+## Install
+
+```sh
+go get -u github.com/workos/workos-go/v2/pkg/events
+```
+
+## How it works

--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -9,3 +9,22 @@ go get -u github.com/workos/workos-go/v2/pkg/events
 ```
 
 ## How it works
+```go
+
+package main
+
+import "github.com/workos/workos-go/v2/pkg/events"
+
+func main() {
+    events.SetAPIKey("my_api_key")
+
+   var  events = []string {"dsync.user.created"}
+
+    events, err := events.GetEvents(ctx.Background(), events.GetEventOpts{
+        Event:     events,
+    })
+    if err != nil {
+        // Handle error.
+    }
+}
+```

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -1,0 +1,135 @@
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/go-querystring/query"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
+
+	"github.com/workos/workos-go/v2/internal/workos"
+	"github.com/workos/workos-go/v2/pkg/common"
+)
+
+// ResponseLimit is the default number of records to limit a response to.
+const ResponseLimit = 10
+
+// Client represents a client that performs Event requests to the WorkOS API.
+type Client struct {
+	// The WorkOS API Key. It can be found in https://dashboard.workos.com/api-keys.
+	APIKey string
+
+	// The http.Client that is used to get Event records from WorkOS.
+	// Defaults to http.Client.
+	HTTPClient *http.Client
+
+	// The endpoint to WorkOS API. Defaults to https://api.workos.com.
+	Endpoint string
+
+	once sync.Once
+}
+
+func (c *Client) init() {
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{Timeout: 10 * time.Second}
+	}
+
+	if c.Endpoint == "" {
+		c.Endpoint = "https://api.workos.com"
+	}
+}
+
+
+// Event contains data about a particular Event.
+type Event struct {
+	// The Event's unique identifier.
+	ID string `json:"id"`
+
+	// The type of Event.
+	Event string `json:"event"`
+
+	// The Event's data in raw encoded JSON.
+	Data json.RawMessage `json:"data"`
+
+	// The Event's created at date.
+	CreatedAt string `json:"created_at"`
+}
+
+// ListeEventsOpts contains the options to request provisioned Events.
+type ListeEventsOpts struct {
+	// Filter to only return Events of particular types.
+	Events string[] `url:"events,omitempty"`
+
+	// Maximum number of records to return.
+	Limit int `url:"limit"`
+
+	// Pagination cursor to receive records after a provided Event ID.
+	After string `url:"after,omitempty"`
+
+	// Date range start for stream of Events.
+	RangeStart string `url:"after,omitempty"`
+
+	// Date range end for stream of Events.
+	RangeEnd string `url:"after,omitempty"`
+}
+
+// ListEventsResponse describes the response structure when requesting
+// Events.
+type ListEventsResponse struct {
+	// List of Events.
+	Data []Event `json:"data"`
+
+	// Cursor pagination options.
+	ListMetadata common.ListMetadata `json:"listMetadata"`
+}
+
+// ListEvents gets a list of Events.
+func (c *Client) ListEvents(
+	ctx context.Context,
+	opts ListeEventsOpts,
+) (ListeEventsOpts, error) {
+	c.once.Do(c.init)
+
+	endpoint := fmt.Sprintf("%s/events", c.Endpoint)
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return ListEventsResponse{}, err
+	}
+
+	req = req.WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	if opts.Limit == 0 {
+		opts.Limit = ResponseLimit
+	}
+
+	v, err := query.Values(opts)
+	if err != nil {
+		return ListEventsResponse{}, err
+	}
+
+	req.URL.RawQuery = v.Encode()
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return ListEventsResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return ListEventsResponse{}, err
+	}
+
+	var body ListEventsResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+	return body, err
+}
+

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -70,10 +70,10 @@ type ListEventsOpts struct {
 	After string `url:"after,omitempty"`
 
 	// Date range start for stream of Events.
-	RangeStart string `url:"after,omitempty"`
+	RangeStart string `url:"rangeStart,omitempty"`
 
 	// Date range end for stream of Events.
-	RangeEnd string `url:"after,omitempty"`
+	RangeEnd string `url:"rangeEnd,omitempty"`
 }
 
 // GetEventsResponse describes the response structure when requesting
@@ -111,12 +111,12 @@ func (c *Client) ListEvents(
 		opts.Limit = ResponseLimit
 	}
 
-	v, err := query.Values(opts)
+	queryValues, err := query.Values(opts)
 	if err != nil {
 		return ListEventsResponse{}, err
 	}
 
-	req.URL.RawQuery = v.Encode()
+	req.URL.RawQuery = queryValues.Encode()
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return ListEventsResponse{}, err

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -58,8 +58,8 @@ type Event struct {
 	CreatedAt string `json:"created_at"`
 }
 
-// ListeEventsOpts contains the options to request provisioned Events.
-type ListeEventsOpts struct {
+// GetEventsOpts contains the options to request provisioned Events.
+type GetEventsOpts struct {
 	// Filter to only return Events of particular types.
 	Events []string `url:"events,omitempty"`
 
@@ -76,9 +76,9 @@ type ListeEventsOpts struct {
 	RangeEnd string `url:"after,omitempty"`
 }
 
-// ListEventsResponse describes the response structure when requesting
+// GetEventsResponse describes the response structure when requesting
 // Events.
-type ListEventsResponse struct {
+type GetEventsResponse struct {
 	// List of Events.
 	Data []Event `json:"data"`
 
@@ -86,11 +86,11 @@ type ListEventsResponse struct {
 	ListMetadata common.ListMetadata `json:"listMetadata"`
 }
 
-// ListEvents gets a list of Events.
-func (c *Client) ListEvents(
+// GetEvents gets a list of Events.
+func (c *Client) GetEvents(
 	ctx context.Context,
-	opts ListeEventsOpts,
-) (ListeEventsOpts, error) {
+	opts GetEventsOpts,
+) (GetEventsResponse, error) {
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf("%s/events", c.Endpoint)
@@ -100,7 +100,7 @@ func (c *Client) ListEvents(
 		nil,
 	)
 	if err != nil {
-		return ListEventsResponse{}, err
+		return GetEventsResponse{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -113,21 +113,21 @@ func (c *Client) ListEvents(
 
 	v, err := query.Values(opts)
 	if err != nil {
-		return ListEventsResponse{}, err
+		return GetEventsResponse{}, err
 	}
 
 	req.URL.RawQuery = v.Encode()
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return ListEventsResponse{}, err
+		return GetEventsResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos_errors.TryGetHTTPError(res); err != nil {
-		return ListEventsResponse{}, err
+		return GetEventsResponse{}, err
 	}
 
-	var body ListEventsResponse
+	var body GetEventsResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -55,11 +55,11 @@ type Event struct {
 	Data json.RawMessage `json:"data"`
 
 	// The Event's created at date.
-	CreatedAt string `json:"created_at"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
-// GetEventsOpts contains the options to request provisioned Events.
-type GetEventsOpts struct {
+// ListEventsOpts contains the options to request provisioned Events.
+type ListEventsOpts struct {
 	// Filter to only return Events of particular types.
 	Events []string `url:"events,omitempty"`
 
@@ -78,7 +78,7 @@ type GetEventsOpts struct {
 
 // GetEventsResponse describes the response structure when requesting
 // Events.
-type GetEventsResponse struct {
+type ListEventsResponse struct {
 	// List of Events.
 	Data []Event `json:"data"`
 
@@ -86,11 +86,11 @@ type GetEventsResponse struct {
 	ListMetadata common.ListMetadata `json:"listMetadata"`
 }
 
-// GetEvents gets a list of Events.
-func (c *Client) GetEvents(
+// ListEvents gets a list of Events.
+func (c *Client) ListEvents(
 	ctx context.Context,
-	opts GetEventsOpts,
-) (GetEventsResponse, error) {
+	opts ListEventsOpts,
+) (ListEventsResponse, error) {
 	c.once.Do(c.init)
 
 	endpoint := fmt.Sprintf("%s/events", c.Endpoint)
@@ -100,7 +100,7 @@ func (c *Client) GetEvents(
 		nil,
 	)
 	if err != nil {
-		return GetEventsResponse{}, err
+		return ListEventsResponse{}, err
 	}
 
 	req = req.WithContext(ctx)
@@ -113,21 +113,21 @@ func (c *Client) GetEvents(
 
 	v, err := query.Values(opts)
 	if err != nil {
-		return GetEventsResponse{}, err
+		return ListEventsResponse{}, err
 	}
 
 	req.URL.RawQuery = v.Encode()
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return GetEventsResponse{}, err
+		return ListEventsResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos_errors.TryGetHTTPError(res); err != nil {
-		return GetEventsResponse{}, err
+		return ListEventsResponse{}, err
 	}
 
-	var body GetEventsResponse
+	var body ListEventsResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 	return body, err

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -1,3 +1,4 @@
+package events
 
 import (
 	"context"
@@ -42,7 +43,6 @@ func (c *Client) init() {
 	}
 }
 
-
 // Event contains data about a particular Event.
 type Event struct {
 	// The Event's unique identifier.
@@ -61,7 +61,7 @@ type Event struct {
 // ListeEventsOpts contains the options to request provisioned Events.
 type ListeEventsOpts struct {
 	// Filter to only return Events of particular types.
-	Events string[] `url:"events,omitempty"`
+	Events []string `url:"events,omitempty"`
 
 	// Maximum number of records to return.
 	Limit int `url:"limit"`
@@ -132,4 +132,3 @@ func (c *Client) ListEvents(
 	err = dec.Decode(&body)
 	return body, err
 }
-

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -1,0 +1,1 @@
+package events

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/workos/workos-go/v2/pkg/common"
 )
 
-func TestGetEvents(t *testing.T) {
+func TestListEvents(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  GetEventsOpts
-		expected GetEventsResponse
+		options  ListEventsOpts
+		expected ListEventsResponse
 		err      bool
 	}{
 		{
@@ -30,8 +30,8 @@ func TestGetEvents(t *testing.T) {
 			client: &Client{
 				APIKey: "test",
 			},
-			options: GetEventsOpts{},
-			expected: GetEventsResponse{
+			options: ListEventsOpts{},
+			expected: ListEventsResponse{
 				Data: []Event{
 					Event{
 						ID:    "event_abcd1234",
@@ -55,7 +55,7 @@ func TestGetEvents(t *testing.T) {
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			events, err := client.GetEvents(context.Background(), test.options)
+			events, err := client.ListEvents(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -79,9 +79,9 @@ func getEventsTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(struct {
-		GetEventsResponse
+		ListEventsResponse
 	}{
-		GetEventsResponse: GetEventsResponse{
+		ListEventsResponse: ListEventsResponse{
 			Data: []Event{
 				{
 					ID:    "event_abcd1234",

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -13,60 +13,36 @@ import (
 )
 
 func TestListEvents(t *testing.T) {
-	tests := []struct {
-		scenario string
-		client   *Client
-		options  ListEventsOpts
-		expected ListEventsResponse
-		err      bool
-	}{
-		{
-			scenario: "Request without API Key returns an error",
-			client:   &Client{},
-			err:      true,
-		},
-		{
-			scenario: "Request returns Events",
-			client: &Client{
-				APIKey: "test",
-			},
-			options: ListEventsOpts{},
-			expected: ListEventsResponse{
-				Data: []Event{
-					Event{
-						ID:    "event_abcd1234",
-						Event: "dsync.user.created",
-						Data:  json.RawMessage(`{"foo":"bar"}`),
-					},
-				},
-				ListMetadata: common.ListMetadata{
-					After: "",
+	t.Run("ListEvents succeeds to fetch Events", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(ListEventsTestHandler))
+		defer server.Close()
+		client := &Client{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			APIKey:     "test",
+		}
+
+		expectedResponse := ListEventsResponse{
+			Data: []Event{
+				{
+					ID:    "event_abcd1234",
+					Event: "dsync.user.created",
+					Data:  json.RawMessage(`{"foo":"bar"}`),
 				},
 			},
-		},
-	}
+			ListMetadata: common.ListMetadata{
+				After: "",
+			},
+		}
 
-	for _, test := range tests {
-		t.Run(test.scenario, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(getEventsTestHandler))
-			defer server.Close()
+		events, err := client.ListEvents(context.Background(), ListEventsOpts{})
 
-			client := test.client
-			client.Endpoint = server.URL
-			client.HTTPClient = server.Client()
-
-			events, err := client.ListEvents(context.Background(), test.options)
-			if test.err {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, test.expected, events)
-		})
-	}
+		require.NoError(t, err)
+		require.Equal(t, expectedResponse, events)
+	})
 }
 
-func getEventsTestHandler(w http.ResponseWriter, r *http.Request) {
+func ListEventsTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {
 		http.Error(w, "bad auth", http.StatusUnauthorized)

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -1,1 +1,104 @@
 package events
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/workos/workos-go/v2/pkg/common"
+)
+
+func TestGetEvents(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  GetEventsOpts
+		expected GetEventsResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   &Client{},
+			err:      true,
+		},
+		{
+			scenario: "Request returns Events",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: GetEventsOpts{},
+			expected: GetEventsResponse{
+				Data: []Event{
+					Event{
+						ID:    "event_abcd1234",
+						Event: "dsync.user.created",
+						Data:  json.RawMessage(`{"foo":"bar"}`),
+					},
+				},
+				ListMetadata: common.ListMetadata{
+					After: "",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(getEventsTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			events, err := client.GetEvents(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, events)
+		})
+	}
+}
+
+func getEventsTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(struct {
+		GetEventsResponse
+	}{
+		GetEventsResponse: GetEventsResponse{
+			Data: []Event{
+				{
+					ID:    "event_abcd1234",
+					Event: "dsync.user.created",
+					Data:  json.RawMessage(`{"foo":"bar"}`),
+				},
+			},
+			ListMetadata: common.ListMetadata{
+				After: "",
+			},
+		},
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -17,10 +17,10 @@ func SetAPIKey(apiKey string) {
 	DefaultClient.APIKey = apiKey
 }
 
-// GetEvents gets a list of Events for an environment.
-func GetEvents(
+// ListEvents gets a list of Events for an environment.
+func ListEvents(
 	ctx context.Context,
-	opts GetEventsOpts,
-) (GetEventsResponse, error) {
-	return DefaultClient.GetEvents(ctx, opts)
+	opts ListEventsOpts,
+) (ListEventsResponse, error) {
+	return DefaultClient.ListEvents(ctx, opts)
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -3,7 +3,6 @@ package events
 
 import (
 	"context"
-	"errors"
 )
 
 // DefaultClient is the client used by SetAPIKey and Event functions.

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,0 +1,28 @@
+// Package `events` provides a client wrapping the WorkOS Events API.
+package events 
+
+import (
+	"context"
+	"errors"
+)
+
+// DefaultClient is the client used by SetAPIKey and Event functions.
+var (
+	DefaultClient = &Client{
+		Endpoint: "https://api.workos.com",
+	}
+)
+
+// SetAPIKey sets the WorkOS API key for Events requests.
+func SetAPIKey(apiKey string) {
+	DefaultClient.APIKey = apiKey
+}
+
+// GetEvents gets a list of Events for an environment.
+func GetEvents(
+	ctx context.Context,
+	opts GetEventsOpts,
+) (GetEventsResponse, error) {
+	return DefaultClient.GetEvents(ctx, opts)
+}
+

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,5 +1,5 @@
 // Package `events` provides a client wrapping the WorkOS Events API.
-package events 
+package events
 
 import (
 	"context"
@@ -25,4 +25,3 @@ func GetEvents(
 ) (GetEventsResponse, error) {
 	return DefaultClient.GetEvents(ctx, opts)
 }
-

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,0 +1,1 @@
+package events

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,1 +1,40 @@
 package events
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/workos/workos-go/v2/pkg/common"
+)
+
+func TestEventsGetEvents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getEventsTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedResponse := GetEventsResponse{
+		Data: []Event{
+			{
+				ID:    "event_abcd1234",
+				Event: "dsync.user.created",
+				Data:  json.RawMessage(`{"foo":"bar"}`),
+			},
+		},
+		ListMetadata: common.ListMetadata{
+			After: "",
+		},
+	}
+	eventsResponse, err := GetEvents(context.Background(), GetEventsOpts{})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, eventsResponse)
+}

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/workos/workos-go/v2/pkg/common"
 )
 
-func TestEventsGetEvents(t *testing.T) {
+func TestEventsListEvents(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(getEventsTestHandler))
 	defer server.Close()
 
@@ -21,7 +21,7 @@ func TestEventsGetEvents(t *testing.T) {
 	}
 	SetAPIKey("test")
 
-	expectedResponse := GetEventsResponse{
+	expectedResponse := ListEventsResponse{
 		Data: []Event{
 			{
 				ID:    "event_abcd1234",
@@ -33,7 +33,7 @@ func TestEventsGetEvents(t *testing.T) {
 			After: "",
 		},
 	}
-	eventsResponse, err := GetEvents(context.Background(), GetEventsOpts{})
+	eventsResponse, err := ListEvents(context.Background(), ListEventsOpts{})
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, eventsResponse)

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEventsListEvents(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(getEventsTestHandler))
+	server := httptest.NewServer(http.HandlerFunc(ListEventsTestHandler))
 	defer server.Close()
 
 	DefaultClient = &Client{


### PR DESCRIPTION
## Description
Adding beta support for the Events API. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ X ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
