### PR TITLE
Use snake case for Events range params

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -70,10 +70,10 @@ type ListEventsOpts struct {
 	After string `url:"after,omitempty"`
 
 	// Date range start for stream of Events.
-	RangeStart string `url:"rangeStart,omitempty"`
+	RangeStart string `url:"range_start,omitempty"`
 
 	// Date range end for stream of Events.
-	RangeEnd string `url:"rangeEnd,omitempty"`
+	RangeEnd string `url:"range_end,omitempty"`
 }
 
 // GetEventsResponse describes the response structure when requesting

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -42,7 +42,7 @@ func TestListEvents(t *testing.T) {
 		require.Equal(t, expectedResponse, events)
 	})
 
-	t.Run("ListEvents succeeds to fetch Events with a RangeStart and RangeEnd", func(t *testing.T) {
+	t.Run("ListEvents succeeds to fetch Events with a range_start and range_end", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(ListEventsTestHandler))
 		defer server.Close()
 		client := &Client{

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -42,7 +42,7 @@ func TestListEvents(t *testing.T) {
 		require.Equal(t, expectedResponse, events)
 	})
 
-	t.Run("ListEvents succeeds to fetch Events with a startRange and endRange", func(t *testing.T) {
+	t.Run("ListEvents succeeds to fetch Events with a RangeStart and RangeEnd", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(ListEventsTestHandler))
 		defer server.Close()
 		client := &Client{


### PR DESCRIPTION
## Description
Use snake case for range params in the Events API. This makes Events consistent with the rest of our API.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
