### PR TITLE
Update version to v2.1.3

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v2.1.2"
+	Version = "v2.1.3"
 )


### PR DESCRIPTION
## Description
* Changed the Events API (in beta) `rangeStart` and `rangeEnd` parameters to `range_start` and `range_end` (https://github.com/workos/workos-go/pull/210)

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
