### PR TITLE
Use list_metadata instead of listMetadata for events 

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -83,7 +83,7 @@ type ListEventsResponse struct {
 	Data []Event `json:"data"`
 
 	// Cursor pagination options.
-	ListMetadata common.ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"list_metadata"`
 }
 
 // ListEvents gets a list of Events.


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
