### PR TITLE
Remove API key from authentication headers 

### DIFF
--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -455,8 +455,8 @@ func (c *Client) VerifySession(ctx context.Context, opts VerifySessionOpts) (Ver
 }
 
 type RevokeSessionOpts struct {
-	SessionToken string `json:"session_token"`
-	SessionID    string `json:"session_id"`
+	SessionToken string `json:"session_token,omitempty"`
+	SessionID    string `json:"session_id,omitempty"`
 }
 
 func (c *Client) RevokeSession(ctx context.Context, opts RevokeSessionOpts) (bool, error) {

--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -260,9 +260,11 @@ func (c *Client) AuthenticateUserWithPassword(ctx context.Context, opts Authenti
 	payload := struct {
 		AuthenticateUserWithPasswordOpts
 		ClientSecret string `json:"client_secret"`
+		GrantType    string `json:"grant_type`
 	}{
 		AuthenticateUserWithPasswordOpts: opts,
 		ClientSecret:                     c.APIKey,
+		GrantType:                        "password",
 	}
 
 	jsonData, err := json.Marshal(payload)

--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -343,7 +343,6 @@ func (c *Client) AuthenticateUserWithToken(ctx context.Context, opts Authenticat
 	// Add headers and context to the request
 	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
-	req.Header.Set("Authorization", "Bearer "+c.APIKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	// Execute the request

--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -316,9 +316,11 @@ func (c *Client) AuthenticateUserWithToken(ctx context.Context, opts Authenticat
 	payload := struct {
 		AuthenticateUserWithTokenOpts
 		ClientSecret string `json:"client_secret"`
+		GrantType    string `json:"grant_type"`
 	}{
 		AuthenticateUserWithTokenOpts: opts,
 		ClientSecret:                  c.APIKey,
+		GrantType:                     "authorization_code",
 	}
 
 	jsonData, err := json.Marshal(payload)

--- a/pkg/users/client_test.go
+++ b/pkg/users/client_test.go
@@ -484,11 +484,6 @@ func TestAuthenticateUserWithPassword(t *testing.T) {
 		err      bool
 	}{
 		{
-			scenario: "Request without API Key returns an error",
-			client:   NewClient(""),
-			err:      true,
-		},
-		{
 			scenario: "Request returns an AuthenticationResponse",
 			client:   NewClient("test"),
 			options: AuthenticateUserWithPasswordOpts{
@@ -532,26 +527,26 @@ func TestAuthenticateUserWithPassword(t *testing.T) {
 }
 
 func getAuthenticationResponseHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Header.Get("Authorization") == "Bearer test" {
-		response := AuthenticationResponse{
-			Session: Session{
-				ID:        "testSessionID",
-				Token:     "testSessionToken",
-				CreatedAt: "2023-08-05T14:48:00.000Z",
-				ExpiresAt: "2023-08-05T14:50:00.000Z",
-			},
-			User: User{
-				ID:        "testUserID",
-				FirstName: "John",
-				LastName:  "Doe",
-				Email:     "employee@foo-corp.com",
-			},
-		}
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
-		return
+
+	response := AuthenticationResponse{
+		Session: Session{
+			ID:        "testSessionID",
+			Token:     "testSessionToken",
+			CreatedAt: "2023-08-05T14:48:00.000Z",
+			ExpiresAt: "2023-08-05T14:50:00.000Z",
+		},
+		User: User{
+			ID:        "testUserID",
+			FirstName: "John",
+			LastName:  "Doe",
+			Email:     "employee@foo-corp.com",
+		},
 	}
-	w.WriteHeader(http.StatusUnauthorized)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+	return
+
 }
 
 func TestAuthenticateUserWithToken(t *testing.T) {
@@ -562,11 +557,6 @@ func TestAuthenticateUserWithToken(t *testing.T) {
 		expected AuthenticationResponse
 		err      bool
 	}{
-		{
-			scenario: "Request without API Key returns an error",
-			client:   NewClient(""),
-			err:      true,
-		},
 		{
 			scenario: "Request returns an AuthenticationResponse",
 			client:   NewClient("test"),


### PR DESCRIPTION
## Description


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
