### PR TITLE
Make password optional when creating users

### DIFF
--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -131,7 +131,7 @@ type ListUsersOpts struct {
 
 type CreateUserOpts struct {
 	Email         string `json:"email"`
-	Password      string `json:"password"`
+	Password      string `json:"password,omitempty"`
 	FirstName     string `json:"first_name,omitempty"`
 	LastName      string `json:"last_name,omitempty"`
 	EmailVerified bool   `json:"email_verified,omitempty"`


### PR DESCRIPTION
## Description

Password is now optional when creating users in the API as of https://github.com/workos/workos/pull/22384. This matches it.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
