### PR TITLE
Add `ClientID` to `AuthenticateUserWithPasswordOpts`

### DIFF
--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -169,13 +169,12 @@ type UnauthorizedOrganization struct {
 }
 
 type AuthenticateUserWithPasswordOpts struct {
-	ClientID     string `json:"client_id"`
-	Email        string `json:"email"`
-	Password     string `json:"password"`
-	IPAddress    string `json:"ip_address,omitempty"`
-	UserAgent    string `json:"user_agent,omitempty"`
-	StartSession bool   `json:"start_session,omitempty"`
-	ExpiresIn    int    `json:"expires_in,omitempty"`
+	ClientID  string `json:"client_id"`
+	Email     string `json:"email"`
+	Password  string `json:"password"`
+	IPAddress string `json:"ip_address,omitempty"`
+	UserAgent string `json:"user_agent,omitempty"`
+	ExpiresIn int    `json:"expires_in,omitempty"`
 }
 
 type AuthenticateUserWithTokenOpts struct {

--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -169,6 +169,7 @@ type UnauthorizedOrganization struct {
 }
 
 type AuthenticateUserWithPasswordOpts struct {
+	ClientID     string `json:"client_id"`
 	Email        string `json:"email"`
 	Password     string `json:"password"`
 	IPAddress    string `json:"ip_address,omitempty"`

--- a/pkg/users/client_test.go
+++ b/pkg/users/client_test.go
@@ -515,6 +515,7 @@ func TestAuthenticateUserWithPassword(t *testing.T) {
 			scenario: "Request returns an AuthenticationResponse",
 			client:   NewClient("test"),
 			options: AuthenticateUserWithPasswordOpts{
+				ClientID: "project_123",
 				Email:    "employee@foo-corp.com",
 				Password: "test_123",
 			},


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
