### PR TITLE
Fix grant type on `AuthenticateUserWithPasswordOpts`

### DIFF
--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -498,7 +498,7 @@ func (c *Client) AuthenticateUserWithPassword(ctx context.Context, opts Authenti
 	payload := struct {
 		AuthenticateUserWithPasswordOpts
 		ClientSecret string `json:"client_secret"`
-		GrantType    string `json:"grant_type`
+		GrantType    string `json:"grant_type"`
 	}{
 		AuthenticateUserWithPasswordOpts: opts,
 		ClientSecret:                     c.APIKey,


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
