### PR TITLE
Rename `AuthenticateUserWithToken` to `AuthenticateUserWithCode`

### DIFF
--- a/pkg/audittrail/audittrail.go
+++ b/pkg/audittrail/audittrail.go
@@ -1,25 +1,26 @@
 // Package `audittrail` provides a client wrapping the WorkOS Audit Trail API.
 //
 // Example:
-//   func main() {
-//       audittrail.SetAPIKey("my_api_key")
 //
-//       // Wherever you need to publish an audit trail event:
-//       err := audittrail.Publish(context.Background(), audittrail.EventOpts{
-//           Action:     "document.viewed",
-//           ActionType: audittrail.Create,
-//           ActorName:  "Jairo Kunde",
-//           ActorID:    "user_01DGZ0FAXN978HCET66Q98QMTQ",
-//           Group:      "abstract.com",
-//           Location:   "55.27.223.26",
-//           OccurredAt: time.Now(),
-//           TargetName: "central.class",
-//           TargetID:   "doc_01DGZ0FAXP4HA4X0BVFKS0ZH4Y",
-//       })
-//       if err != nil {
-//           // Handle error.
-//       }
-//   }
+//	func main() {
+//	    audittrail.SetAPIKey("my_api_key")
+//
+//	    // Wherever you need to publish an audit trail event:
+//	    err := audittrail.Publish(context.Background(), audittrail.EventOpts{
+//	        Action:     "document.viewed",
+//	        ActionType: audittrail.Create,
+//	        ActorName:  "Jairo Kunde",
+//	        ActorID:    "user_01DGZ0FAXN978HCET66Q98QMTQ",
+//	        Group:      "abstract.com",
+//	        Location:   "55.27.223.26",
+//	        OccurredAt: time.Now(),
+//	        TargetName: "central.class",
+//	        TargetID:   "doc_01DGZ0FAXP4HA4X0BVFKS0ZH4Y",
+//	    })
+//	    if err != nil {
+//	        // Handle error.
+//	    }
+//	}
 package audittrail
 
 import (

--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -177,7 +177,7 @@ type AuthenticateUserWithPasswordOpts struct {
 	ExpiresIn int    `json:"expires_in,omitempty"`
 }
 
-type AuthenticateUserWithTokenOpts struct {
+type AuthenticateUserWithCodeOpts struct {
 	ClientID  string `json:"client_id"`
 	Code      string `json:"code"`
 	ExpiresIn int    `json:"expires_in,omitempty"`
@@ -544,17 +544,17 @@ func (c *Client) AuthenticateUserWithPassword(ctx context.Context, opts Authenti
 	return body, err
 }
 
-// AuthenticateUserWithToken authenticates an OAuth user or a managed SSO user that is logging in through SSO, and
+// AuthenticateUserWithCode authenticates an OAuth user or a managed SSO user that is logging in through SSO, and
 // optionally creates a session.
-func (c *Client) AuthenticateUserWithToken(ctx context.Context, opts AuthenticateUserWithTokenOpts) (AuthenticationResponse, error) {
+func (c *Client) AuthenticateUserWithCode(ctx context.Context, opts AuthenticateUserWithCodeOpts) (AuthenticationResponse, error) {
 	payload := struct {
-		AuthenticateUserWithTokenOpts
+		AuthenticateUserWithCodeOpts
 		ClientSecret string `json:"client_secret"`
 		GrantType    string `json:"grant_type"`
 	}{
-		AuthenticateUserWithTokenOpts: opts,
-		ClientSecret:                  c.APIKey,
-		GrantType:                     "authorization_code",
+		AuthenticateUserWithCodeOpts: opts,
+		ClientSecret:                 c.APIKey,
+		GrantType:                    "authorization_code",
 	}
 
 	jsonData, err := json.Marshal(payload)

--- a/pkg/users/client_test.go
+++ b/pkg/users/client_test.go
@@ -580,11 +580,11 @@ func TestAuthenticateUserWithPassword(t *testing.T) {
 	}
 }
 
-func TestAuthenticateUserWithToken(t *testing.T) {
+func TestAuthenticateUserWithCode(t *testing.T) {
 	tests := []struct {
 		scenario string
 		client   *Client
-		options  AuthenticateUserWithTokenOpts
+		options  AuthenticateUserWithCodeOpts
 		expected AuthenticationResponse
 		err      bool
 	}{{
@@ -595,7 +595,7 @@ func TestAuthenticateUserWithToken(t *testing.T) {
 		{
 			scenario: "Request returns an AuthenticationResponse",
 			client:   NewClient("test"),
-			options: AuthenticateUserWithTokenOpts{
+			options: AuthenticateUserWithCodeOpts{
 				ClientID: "project_123",
 				Code:     "test_123",
 			},
@@ -649,7 +649,7 @@ func TestAuthenticateUserWithToken(t *testing.T) {
 			client.Endpoint = server.URL
 			client.HTTPClient = server.Client()
 
-			authenticationresponse, err := client.AuthenticateUserWithToken(context.Background(), test.options)
+			authenticationresponse, err := client.AuthenticateUserWithCode(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -87,13 +87,13 @@ func AuthenticateUserWithPassword(
 	return DefaultClient.AuthenticateUserWithPassword(ctx, opts)
 }
 
-// AuthenticateUserWithToken authenticates an OAuth user or a managed SSO user that is logging in through SSO, and
+// AuthenticateUserWithCode authenticates an OAuth user or a managed SSO user that is logging in through SSO, and
 // optionally creates a session.
-func AuthenticateUserWithToken(
+func AuthenticateUserWithCode(
 	ctx context.Context,
-	opts AuthenticateUserWithTokenOpts,
+	opts AuthenticateUserWithCodeOpts,
 ) (AuthenticationResponse, error) {
-	return DefaultClient.AuthenticateUserWithToken(ctx, opts)
+	return DefaultClient.AuthenticateUserWithCode(ctx, opts)
 }
 
 // AuthenticateUserWithMagicAuth authenticates a user by verifying a one-time code sent to the user's email address by

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -276,7 +276,7 @@ func TestUsersCompletePasswordReset(t *testing.T) {
 	require.Equal(t, expectedResponse, userRes)
 }
 
-func TestUsersAuthenticateUserWithToken(t *testing.T) {
+func TestUsersAuthenticateUserWithCode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(authenticationResponseTestHandler))
 
 	defer server.Close()
@@ -325,7 +325,7 @@ func TestUsersAuthenticateUserWithToken(t *testing.T) {
 		},
 	}
 
-	authenticationRes, err := AuthenticateUserWithToken(context.Background(), AuthenticateUserWithTokenOpts{})
+	authenticationRes, err := AuthenticateUserWithCode(context.Background(), AuthenticateUserWithCodeOpts{})
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, authenticationRes)


### PR DESCRIPTION
## Description

This PR renames the `AuthenticateUserWithToken` method to `AuthenticateUserWithCode` to better reflect its usage.

This is a breaking change to the interface of the beta User Management APIs.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
