### PR TITLE
Remove MagicAuthChallenge from public interface

### DIFF
--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -188,12 +188,12 @@ type AuthenticateUserWithCodeOpts struct {
 type MagicAuthChallengeID string
 
 type AuthenticateUserWithMagicAuthOpts struct {
-	ClientID             string               `json:"client_id"`
-	Code                 string               `json:"code"`
-	MagicAuthChallengeID MagicAuthChallengeID `json:"magic_auth_challenge_id"`
-	ExpiresIn            int                  `json:"expires_in,omitempty"`
-	IPAddress            string               `json:"ip_address,omitempty"`
-	UserAgent            string               `json:"user_agent,omitempty"`
+	ClientID  string `json:"client_id"`
+	Code      string `json:"code"`
+	User      string `json:"user_id"`
+	ExpiresIn int    `json:"expires_in,omitempty"`
+	IPAddress string `json:"ip_address,omitempty"`
+	UserAgent string `json:"user_agent,omitempty"`
 }
 
 type AuthenticationResponse struct {
@@ -239,10 +239,6 @@ type ChallengeResponse struct {
 type SendMagicAuthCodeOpts struct {
 	// The email address the one-time code will be sent to.
 	Email string `json:"email_address"`
-}
-
-type MagicAuthChallenge struct {
-	MagicAuthChallengeID MagicAuthChallengeID `json:"id"`
 }
 
 type VerifySessionOpts struct {
@@ -819,7 +815,7 @@ func (c *Client) CompletePasswordReset(ctx context.Context, opts CompletePasswor
 }
 
 // SendMagicAuthCode creates a one-time Magic Auth code and emails it to the user.
-func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOpts) (MagicAuthChallengeID, error) {
+func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOpts) (User, error) {
 	endpoint := fmt.Sprintf(
 		"%s/users/magic_auth/send",
 		c.Endpoint,
@@ -853,9 +849,9 @@ func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOp
 		return "", err
 	}
 
-	var body MagicAuthChallenge
+	var body User
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 
-	return body.MagicAuthChallengeID, err
+	return body, err
 }

--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -823,7 +823,7 @@ func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOp
 
 	data, err := c.JSONEncode(opts)
 	if err != nil {
-		return "", err
+		return User{}, err
 	}
 
 	req, err := http.NewRequest(
@@ -832,7 +832,7 @@ func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOp
 		bytes.NewBuffer(data),
 	)
 	if err != nil {
-		return "", err
+		return User{}, err
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
@@ -841,12 +841,12 @@ func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOp
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return "", err
+		return User{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos_errors.TryGetHTTPError(res); err != nil {
-		return "", err
+		return User{}, err
 	}
 
 	var body User

--- a/pkg/users/client_test.go
+++ b/pkg/users/client_test.go
@@ -676,9 +676,9 @@ func TestAuthenticateUserWithMagicAuth(t *testing.T) {
 			scenario: "Request returns an AuthenticationResponse",
 			client:   NewClient("test"),
 			options: AuthenticateUserWithMagicAuthOpts{
-				ClientID:             "project_123",
-				Code:                 "test_123",
-				MagicAuthChallengeID: "testMagicAuthChallengeID",
+				ClientID: "project_123",
+				Code:     "test_123",
+				User:     "user_123",
 			},
 			expected: AuthenticationResponse{
 				Session: Session{
@@ -1142,7 +1142,7 @@ func TestSendMagicAuthCode(t *testing.T) {
 		scenario string
 		client   *Client
 		options  SendMagicAuthCodeOpts
-		expected MagicAuthChallengeID
+		expected User
 		err      bool
 	}{
 		{
@@ -1156,7 +1156,16 @@ func TestSendMagicAuthCode(t *testing.T) {
 			options: SendMagicAuthCodeOpts{
 				Email: "marcelina@foo-corp.com",
 			},
-			expected: "testMagicAuthChallengeID",
+			expected: User{
+				ID:           "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+				UserType:     Managed,
+				Email:        "marcelina@foo-corp.com",
+				FirstName:    "Marcelina",
+				LastName:     "Davis",
+				SSOProfileID: "prof_01E55M8ZA10HV0XERJYW0PM277",
+				CreatedAt:    "2021-06-25T19:07:33.155Z",
+				UpdatedAt:    "2021-06-25T19:07:33.155Z",
+			},
 		},
 	}
 
@@ -1191,8 +1200,15 @@ func sendMagicAuthCodeTestHandler(w http.ResponseWriter, r *http.Request) {
 	var err error
 
 	if r.URL.Path == "/users/magic_auth/send" {
-		body, err = json.Marshal(MagicAuthChallenge{
-			MagicAuthChallengeID: "testMagicAuthChallengeID",
+		body, err = json.Marshal(User{
+			ID:           "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+			UserType:     Managed,
+			Email:        "marcelina@foo-corp.com",
+			FirstName:    "Marcelina",
+			LastName:     "Davis",
+			SSOProfileID: "prof_01E55M8ZA10HV0XERJYW0PM277",
+			CreatedAt:    "2021-06-25T19:07:33.155Z",
+			UpdatedAt:    "2021-06-25T19:07:33.155Z",
 		})
 	}
 

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -141,6 +141,6 @@ func CompletePasswordReset(
 func SendMagicAuthCode(
 	ctx context.Context,
 	opts SendMagicAuthCodeOpts,
-) (MagicAuthChallengeID, error) {
+) (User, error) {
 	return DefaultClient.SendMagicAuthCode(ctx, opts)
 }


### PR DESCRIPTION
## Description
- Replace `MagicAuthChallengeID` property by `User` (user ID) on `AuthenticateUserWithMagicAuthOpts`
- `SendMagicAuthCode` returns `User` instead of `MagicAuthChallengeID`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
