### PR TITLE
Fix `Users.UpdateUserPassword()` path

### DIFF
--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -397,7 +397,7 @@ func (c *Client) UpdateUser(ctx context.Context, opts UpdateUserOpts) (User, err
 // UpdateUserPassword updates a User password.
 func (c *Client) UpdateUserPassword(ctx context.Context, opts UpdateUserPasswordOpts) (User, error) {
 	endpoint := fmt.Sprintf(
-		"%s/users/%s",
+		"%s/users/%s/password",
 		c.Endpoint,
 		opts.User,
 	)

--- a/pkg/users/client_test.go
+++ b/pkg/users/client_test.go
@@ -441,7 +441,7 @@ func updateUserPasswordTestHandler(w http.ResponseWriter, r *http.Request) {
 	var body []byte
 	var err error
 
-	if r.URL.Path == "/users/user_01E3JC5F5Z1YJNPGVYWV9SX6GH" {
+	if r.URL.Path == "/users/user_01E3JC5F5Z1YJNPGVYWV9SX6GH/password" {
 		body, err = json.Marshal(User{
 			ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
 			Email:         "marcelina@foo-corp.com",

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -135,7 +135,7 @@ func TestUsersUpdateUser(t *testing.T) {
 }
 
 func TestUsersUpdateUserPassword(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(updateUserTestHandler))
+	server := httptest.NewServer(http.HandlerFunc(updateUserPasswordTestHandler))
 	defer server.Close()
 
 	DefaultClient = mockClient(server)


### PR DESCRIPTION
## Description

`UpdateUserPassword` method should call `users/:id/password` path instead of `users/:id`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
