### PR TITLE
Update Email Verification methods

### DIFF
--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -171,7 +171,7 @@ type SendVerificationEmailOpts struct {
 type VerifyEmailCodeOpts struct {
 	// The unique ID of the User whose code will be verified.
 	User string
-	// The verification token emailed to the user.
+	// The verification code emailed to the user.
 	Code string `json:"code"`
 }
 

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -129,27 +129,27 @@ func AuthenticateUserWithMagicAuth(
 	return DefaultClient.AuthenticateUserWithMagicAuth(ctx, opts)
 }
 
-// CreateEmailVerificationChallenge creates an email verification challenge and emails verification token to user.
-func CreateEmailVerificationChallenge(
+// SendVerificationEmail creates an email verification challenge and emails verification token to user.
+func SendVerificationEmail(
 	ctx context.Context,
-	opts CreateEmailVerificationChallengeOpts,
-) (ChallengeResponse, error) {
-	return DefaultClient.CreateEmailVerificationChallenge(ctx, opts)
+	opts SendVerificationEmailOpts,
+) (UserResponse, error) {
+	return DefaultClient.SendVerificationEmail(ctx, opts)
 }
 
-// CompleteEmailVerification verifies user email using verification token that was sent to the user.
-func CompleteEmailVerification(
+// VerifyEmailCode verifies user email using verification token that was sent to the user.
+func VerifyEmailCode(
 	ctx context.Context,
-	opts CompleteEmailVerificationOpts,
-) (User, error) {
-	return DefaultClient.CompleteEmailVerification(ctx, opts)
+	opts VerifyEmailCodeOpts,
+) (UserResponse, error) {
+	return DefaultClient.VerifyEmailCode(ctx, opts)
 }
 
 // CreatePasswordResetChallenge creates a password reset challenge and emails a password reset link to an unmanaged user.
 func CreatePasswordResetChallenge(
 	ctx context.Context,
 	opts CreatePasswordResetChallengeOpts,
-) (ChallengeResponse, error) {
+) (UserResponse, error) {
 	return DefaultClient.CreatePasswordResetChallenge(ctx, opts)
 }
 

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -231,15 +231,15 @@ func TestUsersRemoveUserFromOrganization(t *testing.T) {
 	require.Equal(t, expectedResponse, userRes)
 }
 
-func TestUsersCreateEmailVerificationChallenge(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(createEmailVerificationChallengeHandler))
+func TestUsersSendVerificationEmail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(sendVerificationEmailTestHandler))
 	defer server.Close()
 
 	DefaultClient = mockClient(server)
 
 	SetAPIKey("test")
 
-	expectedResponse := ChallengeResponse{
+	expectedResponse := UserResponse{
 		User: User{
 			ID:            "user_123",
 			Email:         "marcelina@foo-corp.com",
@@ -249,36 +249,37 @@ func TestUsersCreateEmailVerificationChallenge(t *testing.T) {
 			CreatedAt:     "2021-06-25T19:07:33.155Z",
 			UpdatedAt:     "2021-06-25T19:07:33.155Z",
 		},
-		Token: "testToken",
 	}
 
-	userRes, err := CreateEmailVerificationChallenge(context.Background(), CreateEmailVerificationChallengeOpts{
-		User:            "user_123",
-		VerificationUrl: "https://example.com/verify",
+	userRes, err := SendVerificationEmail(context.Background(), SendVerificationEmailOpts{
+		User: "user_123",
 	})
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, userRes)
 }
 
-func TestUsersCompleteEmailVerification(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(completeEmailVerificationHandler))
+func TestUsersVerifyEmailCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(verifyEmailCodeTestHandler))
 	defer server.Close()
 
 	DefaultClient = mockClient(server)
 
 	SetAPIKey("test")
 
-	expectedResponse := User{
-		ID:            "user_123",
-		Email:         "marcelina@foo-corp.com",
-		FirstName:     "Marcelina",
-		LastName:      "Davis",
-		EmailVerified: true,
+	expectedResponse := UserResponse{
+		User: User{
+			ID:            "user_123",
+			Email:         "marcelina@foo-corp.com",
+			FirstName:     "Marcelina",
+			LastName:      "Davis",
+			EmailVerified: true,
+		},
 	}
 
-	userRes, err := CompleteEmailVerification(context.Background(), CompleteEmailVerificationOpts{
-		Token: "testToken",
+	userRes, err := VerifyEmailCode(context.Background(), VerifyEmailCodeOpts{
+		User: "user_123",
+		Code: "testToken",
 	})
 
 	require.NoError(t, err)
@@ -293,7 +294,7 @@ func TestUsersCreatePasswordResetChallenge(t *testing.T) {
 
 	SetAPIKey("test")
 
-	expectedResponse := ChallengeResponse{
+	expectedResponse := UserResponse{
 		User: User{
 			ID:            "user_123",
 			Email:         "marcelina@foo-corp.com",
@@ -303,7 +304,6 @@ func TestUsersCreatePasswordResetChallenge(t *testing.T) {
 			CreatedAt:     "2021-06-25T19:07:33.155Z",
 			UpdatedAt:     "2021-06-25T19:07:33.155Z",
 		},
-		Token: "testToken",
 	}
 
 	userRes, err := CreatePasswordResetChallenge(context.Background(), CreatePasswordResetChallengeOpts{


### PR DESCRIPTION
## Description

- `CreateEmailVerificationChallenge` -> `SendVerificationEmail`
- `CompleteEmailVerificationChallenge` -> `VerifyEmailCode`

Response of both methods is changed to `UserResponse` which contains a nested `User`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
