### PR TITLE
Add `users.AuthenticateWithTOTP()` method

### DIFF
--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -130,6 +130,14 @@ func AuthenticateWithMagicAuth(
 	return DefaultClient.AuthenticateWithMagicAuth(ctx, opts)
 }
 
+// AuthenticateWithTOTP authenticates a user by verifying a time-based one-time password (TOTP)
+func AuthenticateWithTOTP(
+	ctx context.Context,
+	opts AuthenticateWithTOTPOpts,
+) (UserResponse, error) {
+	return DefaultClient.AuthenticateWithTOTP(ctx, opts)
+}
+
 // SendVerificationEmail creates an email verification challenge and emails verification token to user.
 func SendVerificationEmail(
 	ctx context.Context,

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -412,6 +412,30 @@ func TestUsersAuthenticateWithMagicAuth(t *testing.T) {
 	require.Equal(t, expectedResponse, authenticationRes)
 }
 
+func TestUsersAuthenticateWithTOTP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(authenticationResponseTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := UserResponse{
+		User: User{
+			ID:        "testUserID",
+			FirstName: "John",
+			LastName:  "Doe",
+			Email:     "employee@foo-corp.com",
+		},
+	}
+
+	authenticationRes, err := AuthenticateWithTOTP(context.Background(), AuthenticateWithTOTPOpts{})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, authenticationRes)
+}
+
 func TestUsersSendMagicAuthCode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(sendMagicAuthCodeTestHandler))
 


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
