### PR TITLE
Rename password reset methods

### DIFF
--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -154,20 +154,20 @@ func VerifyEmailCode(
 	return DefaultClient.VerifyEmailCode(ctx, opts)
 }
 
-// CreatePasswordResetChallenge creates a password reset challenge and emails a password reset link to an unmanaged user.
-func CreatePasswordResetChallenge(
+// SendPasswordResetEmail creates a password reset challenge and emails a password reset link to an unmanaged user.
+func SendPasswordResetEmail(
 	ctx context.Context,
-	opts CreatePasswordResetChallengeOpts,
+	opts SendPasswordResetEmailOpts,
 ) (UserResponse, error) {
-	return DefaultClient.CreatePasswordResetChallenge(ctx, opts)
+	return DefaultClient.SendPasswordResetEmail(ctx, opts)
 }
 
-// CompletePasswordReset resets user password using token that was sent to the user.
-func CompletePasswordReset(
+// ResetPassword resets user password using token that was sent to the user.
+func ResetPassword(
 	ctx context.Context,
-	opts CompletePasswordResetOpts,
-) (User, error) {
-	return DefaultClient.CompletePasswordReset(ctx, opts)
+	opts ResetPasswordOpts,
+) (UserResponse, error) {
+	return DefaultClient.ResetPassword(ctx, opts)
 }
 
 // SendMagicAuthCode sends a one-time code to the user's email address.

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -288,7 +288,7 @@ func TestUsersVerifyEmailCode(t *testing.T) {
 }
 
 func TestUsersCreatePasswordResetChallenge(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(createPasswordResetChallengeHandler))
+	server := httptest.NewServer(http.HandlerFunc(sendPasswordResetEmailTestHandler))
 	defer server.Close()
 
 	DefaultClient = mockClient(server)
@@ -307,7 +307,7 @@ func TestUsersCreatePasswordResetChallenge(t *testing.T) {
 		},
 	}
 
-	userRes, err := CreatePasswordResetChallenge(context.Background(), CreatePasswordResetChallengeOpts{
+	userRes, err := SendPasswordResetEmail(context.Background(), SendPasswordResetEmailOpts{
 		Email:            "marcelina@foo-corp.com",
 		PasswordResetUrl: "https://example.com/reset",
 	})
@@ -316,23 +316,26 @@ func TestUsersCreatePasswordResetChallenge(t *testing.T) {
 	require.Equal(t, expectedResponse, userRes)
 }
 
-func TestUsersCompletePasswordReset(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(completePasswordResetHandler))
+func TestUsersResetPassword(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(resetPasswordHandler))
 	defer server.Close()
 
 	DefaultClient = mockClient(server)
 
 	SetAPIKey("test")
 
-	expectedResponse := User{
-		ID:            "user_123",
-		Email:         "marcelina@foo-corp.com",
-		FirstName:     "Marcelina",
-		LastName:      "Davis",
-		EmailVerified: true,
+	expectedResponse := UserResponse{
+		User: User{
+			ID: "user_123",
+
+			Email:         "marcelina@foo-corp.com",
+			FirstName:     "Marcelina",
+			LastName:      "Davis",
+			EmailVerified: true,
+		},
 	}
 
-	userRes, err := CompletePasswordReset(context.Background(), CompletePasswordResetOpts{
+	userRes, err := ResetPassword(context.Background(), ResetPasswordOpts{
 		Token: "testToken",
 	})
 


### PR DESCRIPTION
## Description

- Rename `CreatePasswordResetChallenge` to `SendPasswordResetEmail`
- Rename `CompletePasswordReset` to `ResetPassword` and change response

Resolves: USRLD-1094, USRLD-1101

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
