### PR TITLE
Update /users/magic_auth/send to take `email` rather than `email_address`

### DIFF
--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -208,7 +208,7 @@ type UserResponse struct {
 
 type SendMagicAuthCodeOpts struct {
 	// The email address the one-time code will be sent to.
-	Email string `json:"email_address"`
+	Email string `json:"email"`
 }
 
 type AddUserToOrganizationOpts struct {


### PR DESCRIPTION
## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
