### PR TITLE
Fix `SendMagicAuthCode` response type

### DIFF
--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -222,8 +222,10 @@ type RemoveUserFromOrganizationOpts struct {
 }
 
 type EnrollAuthFactorOpts struct {
-	User string
-	Type mfa.FactorType `json:"type"`
+	User       string
+	Type       mfa.FactorType `json:"type"`
+	TOTPIssuer string         `json:"totp_issuer,omitempty"`
+	TOTPUser   string         `json:"totp_user,omitempty"`
 }
 
 type ListAuthFactorsOpts struct {

--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -937,7 +937,7 @@ func (c *Client) ResetPassword(ctx context.Context, opts ResetPasswordOpts) (Use
 }
 
 // SendMagicAuthCode creates a one-time Magic Auth code and emails it to the user.
-func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOpts) (User, error) {
+func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOpts) (UserResponse, error) {
 	endpoint := fmt.Sprintf(
 		"%s/users/magic_auth/send",
 		c.Endpoint,
@@ -945,7 +945,7 @@ func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOp
 
 	data, err := c.JSONEncode(opts)
 	if err != nil {
-		return User{}, err
+		return UserResponse{}, err
 	}
 
 	req, err := http.NewRequest(
@@ -954,7 +954,7 @@ func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOp
 		bytes.NewBuffer(data),
 	)
 	if err != nil {
-		return User{}, err
+		return UserResponse{}, err
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
@@ -963,15 +963,15 @@ func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOp
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return User{}, err
+		return UserResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos_errors.TryGetHTTPError(res); err != nil {
-		return User{}, err
+		return UserResponse{}, err
 	}
 
-	var body User
+	var body UserResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 

--- a/pkg/users/client_test.go
+++ b/pkg/users/client_test.go
@@ -1265,7 +1265,7 @@ func TestSendMagicAuthCode(t *testing.T) {
 		scenario string
 		client   *Client
 		options  SendMagicAuthCodeOpts
-		expected User
+		expected UserResponse
 		err      bool
 	}{
 		{
@@ -1279,13 +1279,15 @@ func TestSendMagicAuthCode(t *testing.T) {
 			options: SendMagicAuthCodeOpts{
 				Email: "marcelina@foo-corp.com",
 			},
-			expected: User{
-				ID:        "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
-				Email:     "marcelina@foo-corp.com",
-				FirstName: "Marcelina",
-				LastName:  "Davis",
-				CreatedAt: "2021-06-25T19:07:33.155Z",
-				UpdatedAt: "2021-06-25T19:07:33.155Z",
+			expected: UserResponse{
+				User: User{
+					ID:        "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+					Email:     "marcelina@foo-corp.com",
+					FirstName: "Marcelina",
+					LastName:  "Davis",
+					CreatedAt: "2021-06-25T19:07:33.155Z",
+					UpdatedAt: "2021-06-25T19:07:33.155Z",
+				},
 			},
 		},
 	}
@@ -1321,13 +1323,15 @@ func sendMagicAuthCodeTestHandler(w http.ResponseWriter, r *http.Request) {
 	var err error
 
 	if r.URL.Path == "/users/magic_auth/send" {
-		body, err = json.Marshal(User{
-			ID:        "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
-			Email:     "marcelina@foo-corp.com",
-			FirstName: "Marcelina",
-			LastName:  "Davis",
-			CreatedAt: "2021-06-25T19:07:33.155Z",
-			UpdatedAt: "2021-06-25T19:07:33.155Z",
+		body, err = json.Marshal(UserResponse{
+			User: User{
+				ID:        "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+				Email:     "marcelina@foo-corp.com",
+				FirstName: "Marcelina",
+				LastName:  "Davis",
+				CreatedAt: "2021-06-25T19:07:33.155Z",
+				UpdatedAt: "2021-06-25T19:07:33.155Z",
+			},
 		})
 	}
 

--- a/pkg/users/users.go
+++ b/pkg/users/users.go
@@ -174,7 +174,7 @@ func ResetPassword(
 func SendMagicAuthCode(
 	ctx context.Context,
 	opts SendMagicAuthCodeOpts,
-) (User, error) {
+) (UserResponse, error) {
 	return DefaultClient.SendMagicAuthCode(ctx, opts)
 }
 

--- a/pkg/users/users_test.go
+++ b/pkg/users/users_test.go
@@ -448,13 +448,15 @@ func TestUsersSendMagicAuthCode(t *testing.T) {
 
 	SetAPIKey("test")
 
-	expectedResponse := User{
-		ID:        "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
-		Email:     "marcelina@foo-corp.com",
-		FirstName: "Marcelina",
-		LastName:  "Davis",
-		CreatedAt: "2021-06-25T19:07:33.155Z",
-		UpdatedAt: "2021-06-25T19:07:33.155Z",
+	expectedResponse := UserResponse{
+		User: User{
+			ID:        "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+			Email:     "marcelina@foo-corp.com",
+			FirstName: "Marcelina",
+			LastName:  "Davis",
+			CreatedAt: "2021-06-25T19:07:33.155Z",
+			UpdatedAt: "2021-06-25T19:07:33.155Z",
+		},
 	}
 
 	authenticationRes, err := SendMagicAuthCode(context.Background(), SendMagicAuthCodeOpts{})


### PR DESCRIPTION
## Description

`SendMagicAuthCode` should return a `UserResponse` instead of `User`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
