### PR TITLE
Add events as string constants

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -42,21 +42,24 @@ func (c *Client) init() {
 		c.Endpoint = "https://api.workos.com"
 	}
 }
- 
 
 const (
+	// Connection Events
+	ConnectionActivated   = "connection.activated"
+	ConnectionDeactivated = "connection.deactived"
+	ConnectionDeleted     = "connection.deleted"
 	// Directory Events
-	DirectoryActivated  = "dsync.activated"
-	DirectoryDeleted    = "dsync.deleted"
+	DirectoryActivated = "dsync.activated"
+	DirectoryDeleted   = "dsync.deleted"
 	// Directory User Events
 	DirectoryUserCreated = "dsync.user.created"
 	DirectoryUserUpdated = "dsync.user.updated"
 	DirectoryUserDeleted = "dsync.user.deleted"
 	// Directory Group Events
-	DirectoryGroupCreated = "dsync.group.created"
-	DirectoryGroupUpdated = "dsync.group.updated"
-	DirectoryGroupDeleted = "dsync.group.deleted"
-	DirectoryGroupUserAdded = "dsync.group.user_added"
+	DirectoryGroupCreated     = "dsync.group.created"
+	DirectoryGroupUpdated     = "dsync.group.updated"
+	DirectoryGroupDeleted     = "dsync.group.deleted"
+	DirectoryGroupUserAdded   = "dsync.group.user_added"
 	DirectroyGroupUserRemoved = "dsync.group.user_removed"
 )
 

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -18,6 +18,26 @@ import (
 // ResponseLimit is the default number of records to limit a response to.
 const ResponseLimit = 10
 
+const (
+	// Connection Events
+	ConnectionActivated   = "connection.activated"
+	ConnectionDeactivated = "connection.deactived"
+	ConnectionDeleted     = "connection.deleted"
+	// Directory Events
+	DirectoryActivated = "dsync.activated"
+	DirectoryDeleted   = "dsync.deleted"
+	// Directory User Events
+	DirectoryUserCreated = "dsync.user.created"
+	DirectoryUserUpdated = "dsync.user.updated"
+	DirectoryUserDeleted = "dsync.user.deleted"
+	// Directory Group Events
+	DirectoryGroupCreated     = "dsync.group.created"
+	DirectoryGroupUpdated     = "dsync.group.updated"
+	DirectoryGroupDeleted     = "dsync.group.deleted"
+	DirectoryGroupUserAdded   = "dsync.group.user_added"
+	DirectroyGroupUserRemoved = "dsync.group.user_removed"
+)
+
 // Client represents a client that performs Event requests to the WorkOS API.
 type Client struct {
 	// The WorkOS API Key. It can be found in https://dashboard.workos.com/api-keys.
@@ -42,26 +62,6 @@ func (c *Client) init() {
 		c.Endpoint = "https://api.workos.com"
 	}
 }
-
-const (
-	// Connection Events
-	ConnectionActivated   = "connection.activated"
-	ConnectionDeactivated = "connection.deactived"
-	ConnectionDeleted     = "connection.deleted"
-	// Directory Events
-	DirectoryActivated = "dsync.activated"
-	DirectoryDeleted   = "dsync.deleted"
-	// Directory User Events
-	DirectoryUserCreated = "dsync.user.created"
-	DirectoryUserUpdated = "dsync.user.updated"
-	DirectoryUserDeleted = "dsync.user.deleted"
-	// Directory Group Events
-	DirectoryGroupCreated     = "dsync.group.created"
-	DirectoryGroupUpdated     = "dsync.group.updated"
-	DirectoryGroupDeleted     = "dsync.group.deleted"
-	DirectoryGroupUserAdded   = "dsync.group.user_added"
-	DirectroyGroupUserRemoved = "dsync.group.user_removed"
-)
 
 // Event contains data about a particular Event.
 type Event struct {

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -42,6 +42,23 @@ func (c *Client) init() {
 		c.Endpoint = "https://api.workos.com"
 	}
 }
+ 
+
+const (
+	// Directory Events
+	DirectoryActivated  = "dsync.activated"
+	DirectoryDeleted    = "dsync.deleted"
+	// Directory User Events
+	DirectoryUserCreated = "dsync.user.created"
+	DirectoryUserUpdated = "dsync.user.updated"
+	DirectoryUserDeleted = "dsync.user.deleted"
+	// Directory Group Events
+	DirectoryGroupCreated = "dsync.group.created"
+	DirectoryGroupUpdated = "dsync.group.updated"
+	DirectoryGroupDeleted = "dsync.group.deleted"
+	DirectoryGroupUserAdded = "dsync.group.user_added"
+	DirectroyGroupUserRemoved = "dsync.group.user_removed"
+)
 
 // Event contains data about a particular Event.
 type Event struct {


### PR DESCRIPTION
## Description

Adds events as strings constants

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
