### PR TITLE
Use list_metadata for User Management

### DIFF
--- a/pkg/users/client.go
+++ b/pkg/users/client.go
@@ -84,7 +84,7 @@ type ListUsersResponse struct {
 	Data []User `json:"data"`
 
 	// Cursor to paginate through the list of Users
-	ListMetadata common.ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"list_metadata"`
 }
 
 type ListUsersOpts struct {
@@ -235,7 +235,7 @@ type ListAuthFactorsOpts struct {
 type ListAuthFactorsResponse struct {
 	Data []mfa.Factor `json:"data"`
 
-	ListMetadata common.ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"list_metadata"`
 }
 
 func NewClient(apiKey string) *Client {


### PR DESCRIPTION
## Description
The User Management list endpoints return only the new-style `list_metadata` not `listMetadata`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
