### PR TITLE
Remove `domains` and `allowProfilesOutsideOrganization` from Organization entity

### DIFF
--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -77,13 +77,6 @@ type Organization struct {
 	// The Organization's name.
 	Name string `json:"name"`
 
-	// Whether Connections within the Organization allow profiles that are
-	// outside of the Organization's configured User Email Domains.
-	AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
-
-	// The Organization's Domains.
-	Domains []OrganizationDomain `json:"domains"`
-
 	// The timestamp of when the Organization was created.
 	CreatedAt string `json:"created_at"`
 
@@ -130,13 +123,6 @@ type CreateOrganizationOpts struct {
 	// Name of the Organization.
 	Name string `json:"name"`
 
-	// Whether Connections within the Organization allow profiles that are
-	// outside of the Organization's configured User Email Domains.
-	AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
-
-	// Domains of the Organization.
-	Domains []string `json:"domains"`
-
 	// Optional unique identifier to ensure idempotency
 	IdempotencyKey string `json:"idempotency_iey,omitempty"`
 }
@@ -148,13 +134,6 @@ type UpdateOrganizationOpts struct {
 
 	// Name of the Organization.
 	Name string
-
-	// Whether Connections within the Organization allow profiles that are
-	// outside of the Organization's configured User Email Domains.
-	AllowProfilesOutsideOrganization bool
-
-	// Domains of the Organization.
-	Domains []string
 }
 
 // GetOrganization gets an Organization.
@@ -292,16 +271,9 @@ func (c *Client) UpdateOrganization(ctx context.Context, opts UpdateOrganization
 	type UpdateOrganizationChangeOpts struct {
 		// Name of the Organization.
 		Name string `json:"name"`
-
-		// Whether Connections within the Organization allow profiles that are
-		// outside of the Organization's configured User Email Domains.
-		AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
-
-		// Domains of the Organization.
-		Domains []string `json:"domains"`
 	}
 
-	update_opts := UpdateOrganizationChangeOpts{opts.Name, opts.AllowProfilesOutsideOrganization, opts.Domains}
+	update_opts := UpdateOrganizationChangeOpts{opts.Name}
 
 	data, err := c.JSONEncode(update_opts)
 	if err != nil {

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -34,15 +34,8 @@ func TestGetOrganization(t *testing.T) {
 				Organization: "organization_id",
 			},
 			expected: Organization{
-				ID:                               "organization_id",
-				Name:                             "Foo Corp",
-				AllowProfilesOutsideOrganization: false,
-				Domains: []OrganizationDomain{
-					OrganizationDomain{
-						ID:     "organization_domain_id",
-						Domain: "foo-corp.com",
-					},
-				},
+				ID:   "organization_id",
+				Name: "Foo Corp",
 			},
 		},
 	}
@@ -75,15 +68,8 @@ func getOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(Organization{
-		ID:                               "organization_id",
-		Name:                             "Foo Corp",
-		AllowProfilesOutsideOrganization: false,
-		Domains: []OrganizationDomain{
-			OrganizationDomain{
-				ID:     "organization_domain_id",
-				Domain: "foo-corp.com",
-			},
-		},
+		ID:   "organization_id",
+		Name: "Foo Corp",
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -119,15 +105,8 @@ func TestListOrganizations(t *testing.T) {
 			expected: ListOrganizationsResponse{
 				Data: []Organization{
 					Organization{
-						ID:                               "organization_id",
-						Name:                             "Foo Corp",
-						AllowProfilesOutsideOrganization: false,
-						Domains: []OrganizationDomain{
-							OrganizationDomain{
-								ID:     "organization_domain_id",
-								Domain: "foo-corp.com",
-							},
-						},
+						ID:   "organization_id",
+						Name: "Foo Corp",
 					},
 				},
 				ListMetadata: common.ListMetadata{
@@ -176,15 +155,8 @@ func listOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
 		ListOrganizationsResponse: ListOrganizationsResponse{
 			Data: []Organization{
 				Organization{
-					ID:                               "organization_id",
-					Name:                             "Foo Corp",
-					AllowProfilesOutsideOrganization: false,
-					Domains: []OrganizationDomain{
-						OrganizationDomain{
-							ID:     "organization_domain_id",
-							Domain: "foo-corp.com",
-						},
-					},
+					ID:   "organization_id",
+					Name: "Foo Corp",
 				},
 			},
 			ListMetadata: common.ListMetadata{
@@ -221,19 +193,11 @@ func TestCreateOrganization(t *testing.T) {
 				APIKey: "test",
 			},
 			options: CreateOrganizationOpts{
-				Name:    "Foo Corp",
-				Domains: []string{"foo-corp.com"},
+				Name: "Foo Corp",
 			},
 			expected: Organization{
-				ID:                               "organization_id",
-				Name:                             "Foo Corp",
-				AllowProfilesOutsideOrganization: false,
-				Domains: []OrganizationDomain{
-					OrganizationDomain{
-						ID:     "organization_domain_id",
-						Domain: "foo-corp.com",
-					},
-				},
+				ID:   "organization_id",
+				Name: "Foo Corp",
 			},
 		},
 		{
@@ -243,8 +207,7 @@ func TestCreateOrganization(t *testing.T) {
 			},
 			err: true,
 			options: CreateOrganizationOpts{
-				Name:    "Foo Corp",
-				Domains: []string{"duplicate.com"},
+				Name: "Foo Corp",
 			},
 		},
 		{
@@ -255,7 +218,6 @@ func TestCreateOrganization(t *testing.T) {
 			err: true,
 			options: CreateOrganizationOpts{
 				Name:           "New Corp",
-				Domains:        []string{"foo-corp.com"},
 				IdempotencyKey: "duplicate",
 			},
 		},
@@ -290,20 +252,7 @@ func createOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	var opts CreateOrganizationOpts
 	json.NewDecoder(r.Body).Decode(&opts)
-	for _, domain := range opts.Domains {
-		if domain == "duplicate.com" {
-			http.Error(w, "duplicate domain", http.StatusConflict)
-			return
-		}
-	}
-
 	if opts.IdempotencyKey == "duplicate" {
-		for _, domain := range opts.Domains {
-			if domain != "foo-corp.com" {
-				http.Error(w, "duplicate idempotency key", http.StatusConflict)
-				return
-			}
-		}
 		if opts.Name != "Foo Corp" {
 			http.Error(w, "duplicate idempotency key", http.StatusConflict)
 			return
@@ -316,15 +265,8 @@ func createOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := json.Marshal(
 		Organization{
-			ID:                               "organization_id",
-			Name:                             "Foo Corp",
-			AllowProfilesOutsideOrganization: false,
-			Domains: []OrganizationDomain{
-				OrganizationDomain{
-					ID:     "organization_domain_id",
-					Domain: "foo-corp.com",
-				},
-			},
+			ID:   "organization_id",
+			Name: "Foo Corp",
 		})
 
 	if err != nil {
@@ -357,22 +299,10 @@ func TestUpdateOrganization(t *testing.T) {
 			options: UpdateOrganizationOpts{
 				Organization: "organization_id",
 				Name:         "Foo Corp",
-				Domains:      []string{"foo-corp.com", "foo-corp.io"},
 			},
 			expected: Organization{
-				ID:                               "organization_id",
-				Name:                             "Foo Corp",
-				AllowProfilesOutsideOrganization: false,
-				Domains: []OrganizationDomain{
-					OrganizationDomain{
-						ID:     "organization_domain_id",
-						Domain: "foo-corp.com",
-					},
-					OrganizationDomain{
-						ID:     "organization_domain_id_2",
-						Domain: "foo-corp.io",
-					},
-				},
+				ID:   "organization_id",
+				Name: "Foo Corp",
 			},
 		},
 		{
@@ -384,7 +314,6 @@ func TestUpdateOrganization(t *testing.T) {
 			options: UpdateOrganizationOpts{
 				Organization: "organization_id",
 				Name:         "Foo Corp",
-				Domains:      []string{"duplicate.com"},
 			},
 		},
 	}
@@ -418,12 +347,6 @@ func updateOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	var opts UpdateOrganizationOpts
 	json.NewDecoder(r.Body).Decode(&opts)
-	for _, domain := range opts.Domains {
-		if domain == "duplicate.com" {
-			http.Error(w, "duplicate domain", http.StatusConflict)
-			return
-		}
-	}
 
 	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
 		w.WriteHeader(http.StatusBadRequest)
@@ -432,19 +355,8 @@ func updateOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := json.Marshal(
 		Organization{
-			ID:                               "organization_id",
-			Name:                             "Foo Corp",
-			AllowProfilesOutsideOrganization: false,
-			Domains: []OrganizationDomain{
-				OrganizationDomain{
-					ID:     "organization_domain_id",
-					Domain: "foo-corp.com",
-				},
-				OrganizationDomain{
-					ID:     "organization_domain_id_2",
-					Domain: "foo-corp.io",
-				},
-			},
+			ID:   "organization_id",
+			Name: "Foo Corp",
 		})
 
 	if err != nil {

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -201,16 +201,6 @@ func TestCreateOrganization(t *testing.T) {
 			},
 		},
 		{
-			scenario: "Request with duplicate Organization Domain returns error",
-			client: &Client{
-				APIKey: "test",
-			},
-			err: true,
-			options: CreateOrganizationOpts{
-				Name: "Foo Corp",
-			},
-		},
-		{
 			scenario: "Idempotency Key with different event payloads returns error",
 			client: &Client{
 				APIKey: "test",
@@ -303,17 +293,6 @@ func TestUpdateOrganization(t *testing.T) {
 			expected: Organization{
 				ID:   "organization_id",
 				Name: "Foo Corp",
-			},
-		},
-		{
-			scenario: "Request with duplicate Organization Domain returns error",
-			client: &Client{
-				APIKey: "test",
-			},
-			err: true,
-			options: UpdateOrganizationOpts{
-				Organization: "organization_id",
-				Name:         "Foo Corp",
 			},
 		},
 	}

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -21,8 +21,8 @@ func TestOrganizationsGetOrganization(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := Organization{
-		ID:                               "organization_id",
-		Name:                             "Foo Corp",
+		ID:   "organization_id",
+		Name: "Foo Corp",
 	}
 	organizationResponse, err := GetOrganization(context.Background(), GetOrganizationOpts{
 		Organization: "organization_id",
@@ -45,8 +45,8 @@ func TestOrganizationsListOrganizations(t *testing.T) {
 	expectedResponse := ListOrganizationsResponse{
 		Data: []Organization{
 			Organization{
-				ID:                               "organization_id",
-				Name:                             "Foo Corp",
+				ID:   "organization_id",
+				Name: "Foo Corp",
 			},
 		},
 		ListMetadata: common.ListMetadata{
@@ -75,8 +75,8 @@ func TestOrganizationsCreateOrganization(t *testing.T) {
 
 	expectedResponse :=
 		Organization{
-			ID:                               "organization_id",
-			Name:                             "Foo Corp",
+			ID:   "organization_id",
+			Name: "Foo Corp",
 		}
 
 	organization, err := CreateOrganization(context.Background(), CreateOrganizationOpts{
@@ -100,8 +100,8 @@ func TestOrganizationsUpdateOrganization(t *testing.T) {
 
 	expectedResponse :=
 		Organization{
-			ID:                               "organization_id",
-			Name:                             "Foo Corp",
+			ID:   "organization_id",
+			Name: "Foo Corp",
 		}
 
 	organization, err := UpdateOrganization(context.Background(), UpdateOrganizationOpts{

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -23,13 +23,6 @@ func TestOrganizationsGetOrganization(t *testing.T) {
 	expectedResponse := Organization{
 		ID:                               "organization_id",
 		Name:                             "Foo Corp",
-		AllowProfilesOutsideOrganization: false,
-		Domains: []OrganizationDomain{
-			OrganizationDomain{
-				ID:     "organization_domain_id",
-				Domain: "foo-corp.com",
-			},
-		},
 	}
 	organizationResponse, err := GetOrganization(context.Background(), GetOrganizationOpts{
 		Organization: "organization_id",
@@ -54,13 +47,6 @@ func TestOrganizationsListOrganizations(t *testing.T) {
 			Organization{
 				ID:                               "organization_id",
 				Name:                             "Foo Corp",
-				AllowProfilesOutsideOrganization: false,
-				Domains: []OrganizationDomain{
-					OrganizationDomain{
-						ID:     "organization_domain_id",
-						Domain: "foo-corp.com",
-					},
-				},
 			},
 		},
 		ListMetadata: common.ListMetadata{
@@ -91,18 +77,10 @@ func TestOrganizationsCreateOrganization(t *testing.T) {
 		Organization{
 			ID:                               "organization_id",
 			Name:                             "Foo Corp",
-			AllowProfilesOutsideOrganization: false,
-			Domains: []OrganizationDomain{
-				OrganizationDomain{
-					ID:     "organization_domain_id",
-					Domain: "foo-corp.com",
-				},
-			},
 		}
 
 	organization, err := CreateOrganization(context.Background(), CreateOrganizationOpts{
 		Name:           "Foo Corp",
-		Domains:        []string{"foo-corp.com"},
 		IdempotencyKey: "duplicate",
 	})
 
@@ -124,23 +102,11 @@ func TestOrganizationsUpdateOrganization(t *testing.T) {
 		Organization{
 			ID:                               "organization_id",
 			Name:                             "Foo Corp",
-			AllowProfilesOutsideOrganization: false,
-			Domains: []OrganizationDomain{
-				OrganizationDomain{
-					ID:     "organization_domain_id",
-					Domain: "foo-corp.com",
-				},
-				OrganizationDomain{
-					ID:     "organization_domain_id_2",
-					Domain: "foo-corp.io",
-				},
-			},
 		}
 
 	organization, err := UpdateOrganization(context.Background(), UpdateOrganizationOpts{
 		Organization: "organization_id",
 		Name:         "Foo Corp",
-		Domains:      []string{"foo-corp.com", "foo-corp.io"},
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

Breaking change. Removes domains and allowProfilesOutsideOrganization from Organization entity.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
