### PR TITLE
Rename Organization to OrganizationID in ListUsersOpts

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -93,7 +93,7 @@ type ListUsersOpts struct {
 	Email string `url:"email,omitempty"`
 
 	// Filter Users by the organization they are members of.
-	Organization string `url:"organization,omitempty"`
+	OrganizationID string `url:"organization_id,omitempty"`
 
 	// Maximum number of records to return.
 	Limit int `url:"limit"`

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -129,6 +129,38 @@ func TestListUsers(t *testing.T) {
 		require.Equal(t, expectedResponse, users)
 	})
 
+	t.Run("ListUsers succeeds to fetch Users belonging to an Organization", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(listUsersTestHandler))
+		defer server.Close()
+		client := &Client{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			APIKey:     "test",
+		}
+
+		expectedResponse := ListUsersResponse{
+			Data: []User{
+				{
+					ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+					Email:         "marcelina@foo-corp.com",
+					FirstName:     "Marcelina",
+					LastName:      "Davis",
+					EmailVerified: true,
+					CreatedAt:     "2021-06-25T19:07:33.155Z",
+					UpdatedAt:     "2021-06-25T19:07:33.155Z",
+				},
+			},
+			ListMetadata: common.ListMetadata{
+				After: "",
+			},
+		}
+
+		users, err := client.ListUsers(context.Background(), ListUsersOpts{OrganizationID: "org_123"})
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResponse, users)
+	})
+
 	t.Run("ListUsers succeeds to fetch Users created after a timestamp", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(listUsersTestHandler))
 		defer server.Close()


### PR DESCRIPTION
## Description
[Breaking change]
Renames Organization to OrganizationID in ListUsersOpts to be consistent with other endpoints.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
