### PR TITLE
Add back usermanagement package

### DIFF
--- a/pkg/usermanagement/README.md
+++ b/pkg/usermanagement/README.md
@@ -1,0 +1,15 @@
+# users
+
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v2/pkg/usermanagement)
+
+A go package to request WorkOS User Management API.
+
+## Install
+
+```sh
+go get -u github.com/workos/workos-go/v2/pkg/usermanagement
+```
+
+## How it works
+
+See the [User Management integration guide](https://workos.com/docs/user-management/).

--- a/pkg/usermanagement/README.md
+++ b/pkg/usermanagement/README.md
@@ -1,13 +1,13 @@
 # users
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v2/pkg/usermanagement)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v3/pkg/usermanagement)
 
 A go package to request WorkOS User Management API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v2/pkg/usermanagement
+go get -u github.com/workos/workos-go/v3/pkg/usermanagement
 ```
 
 ## How it works

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -1,0 +1,1138 @@
+package usermanagement
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/go-querystring/query"
+	"github.com/workos/workos-go/v2/internal/workos"
+	"github.com/workos/workos-go/v2/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/mfa"
+	"github.com/workos/workos-go/v2/pkg/workos_errors"
+)
+
+// ResponseLimit is the default number of records to limit a response to.
+const ResponseLimit = 10
+
+// Order represents the order of records.
+type Order string
+
+// Constants that enumerate the available orders.
+const (
+	Asc  Order = "asc"
+	Desc Order = "desc"
+)
+
+// Organization contains data about a particular Organization.
+type Organization struct {
+	// The Organization's unique identifier.
+	ID string `json:"id"`
+
+	// The Organization's name.
+	Name string `json:"name"`
+}
+
+// OrganizationMembership contains data about a particular OrganizationMembership.
+type OrganizationMembership struct {
+	// The Organization Membership's unique identifier.
+	ID string `json:"id"`
+
+	// The ID of the User.
+	UserID string `json:"user_id"`
+
+	// The ID of the Organization.
+	OrganizationID string `json:"organization_id"`
+
+	// CreatedAt is the timestamp of when the OrganizationMembership was created.
+	CreatedAt string `json:"created_at"`
+
+	// UpdatedAt is the timestamp of when the OrganizationMembership was updated.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// User contains data about a particular User.
+type User struct {
+
+	// The User's unique identifier.
+	ID string `json:"id"`
+
+	// The User's first name.
+	FirstName string `json:"first_name"`
+
+	// The User's last name.
+	LastName string `json:"last_name"`
+
+	// The User's email.
+	Email string `json:"email"`
+
+	// The timestamp of when the User was created.
+	CreatedAt string `json:"created_at"`
+
+	// The timestamp of when the User was updated.
+	UpdatedAt string `json:"updated_at"`
+
+	// Whether the User email is verified.
+	EmailVerified bool `json:"email_verified"`
+}
+
+// GetUserOpts contains the options to pass in order to get a user profile.
+type GetUserOpts struct {
+	// User unique identifier
+	User string `json:"id"`
+}
+
+// ListUsersResponse contains the response from the ListUsers call.
+type ListUsersResponse struct {
+	// List of Users
+	Data []User `json:"data"`
+
+	// Cursor to paginate through the list of Users
+	ListMetadata common.ListMetadata `json:"list_metadata"`
+}
+
+type ListUsersOpts struct {
+	// Filter Users by their email.
+	Email string `url:"email,omitempty"`
+
+	// Filter Users by the organization they are members of.
+	OrganizationID string `url:"organization_id,omitempty"`
+
+	// Maximum number of records to return.
+	Limit int `url:"limit"`
+
+	// The order in which to paginate records.
+	Order Order `url:"order,omitempty"`
+
+	// Pagination cursor to receive records before a provided User ID.
+	Before string `url:"before,omitempty"`
+
+	// Pagination cursor to receive records after a provided User ID.
+	After string `url:"after,omitempty"`
+}
+
+type CreateUserOpts struct {
+	Email         string `json:"email"`
+	Password      string `json:"password,omitempty"`
+	FirstName     string `json:"first_name,omitempty"`
+	LastName      string `json:"last_name,omitempty"`
+	EmailVerified bool   `json:"email_verified,omitempty"`
+}
+
+type UpdateUserOpts struct {
+	User          string
+	FirstName     string `json:"first_name,omitempty"`
+	LastName      string `json:"last_name,omitempty"`
+	EmailVerified bool   `json:"email_verified,omitempty"`
+}
+
+type UpdateUserPasswordOpts struct {
+	User     string
+	Password string `json:"password"`
+}
+
+type DeleteUserOpts struct {
+	User string
+}
+
+type AuthenticateWithPasswordOpts struct {
+	ClientID  string `json:"client_id"`
+	Email     string `json:"email"`
+	Password  string `json:"password"`
+	IPAddress string `json:"ip_address,omitempty"`
+	UserAgent string `json:"user_agent,omitempty"`
+}
+
+type AuthenticateWithCodeOpts struct {
+	ClientID  string `json:"client_id"`
+	Code      string `json:"code"`
+	IPAddress string `json:"ip_address,omitempty"`
+	UserAgent string `json:"user_agent,omitempty"`
+}
+
+type AuthenticateWithMagicAuthOpts struct {
+	ClientID  string `json:"client_id"`
+	Code      string `json:"code"`
+	User      string `json:"user_id"`
+	IPAddress string `json:"ip_address,omitempty"`
+	UserAgent string `json:"user_agent,omitempty"`
+}
+
+type AuthenticateWithTOTPOpts struct {
+	ClientID                   string `json:"client_id"`
+	Code                       string `json:"code"`
+	IPAddress                  string `json:"ip_address,omitempty"`
+	UserAgent                  string `json:"user_agent,omitempty"`
+	PendingAuthenticationToken string `json:"pending_authentication_token"`
+	AuthenticationChallengeID  string `json:"authentication_challenge_id"`
+}
+
+type AuthenticationResponse struct {
+	Factor    mfa.Factor    `json:"authentication_factor"`
+	Challenge mfa.Challenge `json:"authentication_challenge"`
+}
+
+type SendVerificationEmailOpts struct {
+	// The unique ID of the User who will be sent a verification email.
+	User string
+}
+
+type VerifyEmailOpts struct {
+	// The unique ID of the User whose email address will be verified.
+	User string
+	// The verification code emailed to the user.
+	Code string `json:"code"`
+}
+
+type SendPasswordResetEmailOpts struct {
+	// The unique ID of the User whose email address will be verified.
+	Email string `json:"email"`
+
+	// The URL that will be linked to in the verification email.
+	PasswordResetUrl string `json:"password_reset_url"`
+}
+
+type ResetPasswordOpts struct {
+	// The verification token emailed to the user.
+	Token string `json:"token"`
+
+	// The new password to be set for the user.
+	NewPassword string `json:"new_password"`
+}
+
+type UserResponse struct {
+	User User `json:"user"`
+}
+
+type SendMagicAuthCodeOpts struct {
+	// The email address the one-time code will be sent to.
+	Email string `json:"email"`
+}
+
+type EnrollAuthFactorOpts struct {
+	User       string
+	Type       mfa.FactorType `json:"type"`
+	TOTPIssuer string         `json:"totp_issuer,omitempty"`
+	TOTPUser   string         `json:"totp_user,omitempty"`
+}
+
+type ListAuthFactorsOpts struct {
+	User string
+}
+
+type ListAuthFactorsResponse struct {
+	Data []mfa.Factor `json:"data"`
+
+	ListMetadata common.ListMetadata `json:"list_metadata"`
+}
+
+type GetOrganizationMembershipOpts struct {
+	// Organization Membership unique identifier
+	OrganizationMembershipID string
+}
+
+type ListOrganizationMembershipsOpts struct {
+	// Filter memberships by Organization ID.
+	OrganizationID string `url:"organization_id,omitempty"`
+
+	// Filter memberships by User ID.
+	UserID string `url:"user_id,omitempty"`
+
+	// Maximum number of records to return.
+	Limit int `url:"limit"`
+
+	// The order in which to paginate records.
+	Order Order `url:"order,omitempty"`
+
+	// Pagination cursor to receive records before a provided
+	// Organization Membership ID.
+	Before string `url:"before,omitempty"`
+
+	// Pagination cursor to receive records after a provided
+	// Organization Membership ID.
+	After string `url:"after,omitempty"`
+}
+
+type ListOrganizationMembershipsResponse struct {
+	Data []OrganizationMembership `json:"data"`
+
+	ListMetadata common.ListMetadata `json:"list_metadata"`
+}
+
+type CreateOrganizationMembershipOpts struct {
+	// The ID of the User to add as a member.
+	UserID string `json:"user_id"`
+
+	// The ID of the Organization in which to add the User as a member.
+	OrganizationID string `json:"organization_id"`
+}
+
+type DeleteOrganizationMembershipOpts struct {
+	// The ID of the Organization Membership to delete.
+	OrganizationMembershipID string
+}
+
+func NewClient(apiKey string) *Client {
+	return &Client{
+		APIKey:     apiKey,
+		Endpoint:   "https://api.workos.com",
+		HTTPClient: &http.Client{Timeout: time.Second * 10},
+		JSONEncode: json.Marshal,
+	}
+}
+
+// GetUser returns details of an existing user
+func (c *Client) GetUser(ctx context.Context, opts GetUserOpts) (User, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/users/%s",
+		c.Endpoint,
+		opts.User,
+	)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return User{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return User{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return User{}, err
+	}
+
+	var body User
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// ListUsers get a list of all of your existing users matching the criteria specified.
+func (c *Client) ListUsers(ctx context.Context, opts ListUsersOpts) (ListUsersResponse, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/users",
+		c.Endpoint,
+	)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return ListUsersResponse{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	if opts.Limit == 0 {
+		opts.Limit = ResponseLimit
+	}
+
+	queryValues, err := query.Values(opts)
+	if err != nil {
+		return ListUsersResponse{}, err
+	}
+
+	req.URL.RawQuery = queryValues.Encode()
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return ListUsersResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return ListUsersResponse{}, err
+	}
+
+	var body ListUsersResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// CreateUser create a new user with email password authentication.
+// Only unmanaged users can be created directly using the User Management API.
+func (c *Client) CreateUser(ctx context.Context, opts CreateUserOpts) (User, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/users",
+		c.Endpoint,
+	)
+
+	data, err := c.JSONEncode(opts)
+	if err != nil {
+		return User{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		endpoint,
+		bytes.NewBuffer(data),
+	)
+	if err != nil {
+		return User{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return User{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return User{}, err
+	}
+
+	var body User
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// UpdateUser updates User attributes.
+func (c *Client) UpdateUser(ctx context.Context, opts UpdateUserOpts) (User, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/users/%s",
+		c.Endpoint,
+		opts.User,
+	)
+
+	data, err := c.JSONEncode(opts)
+	if err != nil {
+		return User{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPut,
+		endpoint,
+		bytes.NewBuffer(data),
+	)
+	if err != nil {
+		return User{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return User{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return User{}, err
+	}
+
+	var body User
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// DeleteUser delete an existing user.
+func (c *Client) DeleteUser(ctx context.Context, opts DeleteUserOpts) error {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/users/%s",
+		c.Endpoint,
+		opts.User,
+	)
+
+	req, err := http.NewRequest(
+		http.MethodDelete,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	return workos_errors.TryGetHTTPError(res)
+}
+
+// AuthenticateWithPassword authenticates a user with Email and Password
+func (c *Client) AuthenticateWithPassword(ctx context.Context, opts AuthenticateWithPasswordOpts) (UserResponse, error) {
+	payload := struct {
+		AuthenticateWithPasswordOpts
+		ClientSecret string `json:"client_secret"`
+		GrantType    string `json:"grant_type"`
+	}{
+		AuthenticateWithPasswordOpts: opts,
+		ClientSecret:                 c.APIKey,
+		GrantType:                    "password",
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		c.Endpoint+"/user_management/authenticate",
+		bytes.NewBuffer(jsonData),
+	)
+
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	// Add headers and context to the request
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Execute the request
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return UserResponse{}, err
+	}
+
+	// Parse the JSON response
+	var body UserResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// AuthenticateWithCode authenticates an OAuth user or a managed SSO user that is logging in through SSO
+func (c *Client) AuthenticateWithCode(ctx context.Context, opts AuthenticateWithCodeOpts) (UserResponse, error) {
+	payload := struct {
+		AuthenticateWithCodeOpts
+		ClientSecret string `json:"client_secret"`
+		GrantType    string `json:"grant_type"`
+	}{
+		AuthenticateWithCodeOpts: opts,
+		ClientSecret:             c.APIKey,
+		GrantType:                "authorization_code",
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		c.Endpoint+"/user_management/authenticate",
+		bytes.NewBuffer(jsonData),
+	)
+
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	// Add headers and context to the request
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Execute the request
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return UserResponse{}, err
+	}
+
+	// Parse the JSON response
+	var body UserResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// AuthenticateWithMagicAuth authenticates a user by verifying a one-time code sent to the user's email address by
+// the Magic Auth Send Code endpoint.
+func (c *Client) AuthenticateWithMagicAuth(ctx context.Context, opts AuthenticateWithMagicAuthOpts) (UserResponse, error) {
+	payload := struct {
+		AuthenticateWithMagicAuthOpts
+		ClientSecret string `json:"client_secret"`
+		GrantType    string `json:"grant_type"`
+	}{
+		AuthenticateWithMagicAuthOpts: opts,
+		ClientSecret:                  c.APIKey,
+		GrantType:                     "urn:workos:oauth:grant-type:magic-auth:code",
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		c.Endpoint+"/user_management/authenticate",
+		bytes.NewBuffer(jsonData),
+	)
+
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	// Add headers and context to the request
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Execute the request
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return UserResponse{}, err
+	}
+
+	// Parse the JSON response
+	var body UserResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// AuthenticateWithTOTP authenticates a user by verifying a time-based one-time password (TOTP)
+func (c *Client) AuthenticateWithTOTP(ctx context.Context, opts AuthenticateWithTOTPOpts) (UserResponse, error) {
+	payload := struct {
+		AuthenticateWithTOTPOpts
+		ClientSecret string `json:"client_secret"`
+		GrantType    string `json:"grant_type"`
+	}{
+		AuthenticateWithTOTPOpts: opts,
+		ClientSecret:             c.APIKey,
+		GrantType:                "workos:oauth:grant-type:mfa-totp",
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		c.Endpoint+"/user_management/authenticate",
+		bytes.NewBuffer(jsonData),
+	)
+
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	// Add headers and context to the request
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Execute the request
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return UserResponse{}, err
+	}
+
+	// Parse the JSON response
+	var body UserResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// SendVerificationEmail creates an email verification challenge and emails verification token to user.
+func (c *Client) SendVerificationEmail(ctx context.Context, opts SendVerificationEmailOpts) (UserResponse, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/users/%s/email_verification/send",
+		c.Endpoint,
+		opts.User,
+	)
+	req, err := http.NewRequest(
+		http.MethodPost,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return UserResponse{}, err
+	}
+
+	var body UserResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// VerifyEmail verifies a user's email using the verification token that was sent to the user.
+func (c *Client) VerifyEmail(ctx context.Context, opts VerifyEmailOpts) (UserResponse, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/users/%s/email_verification/confirm",
+		c.Endpoint,
+		opts.User,
+	)
+
+	data, err := c.JSONEncode(opts)
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		endpoint,
+		bytes.NewBuffer(data),
+	)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return UserResponse{}, err
+	}
+
+	var body UserResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// SendPasswordResetEmail creates a password reset challenge and emails a password reset link to an
+// unmanaged user.
+func (c *Client) SendPasswordResetEmail(ctx context.Context, opts SendPasswordResetEmailOpts) (UserResponse, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/password_reset/send",
+		c.Endpoint,
+	)
+
+	data, err := c.JSONEncode(opts)
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		endpoint,
+		bytes.NewBuffer(data),
+	)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return UserResponse{}, err
+	}
+
+	var body UserResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// ResetPassword resets user password using token that was sent to the user.
+func (c *Client) ResetPassword(ctx context.Context, opts ResetPasswordOpts) (UserResponse, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/password_reset/confirm",
+		c.Endpoint,
+	)
+
+	data, err := c.JSONEncode(opts)
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		endpoint,
+		bytes.NewBuffer(data),
+	)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return UserResponse{}, err
+	}
+
+	var body UserResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// SendMagicAuthCode creates a one-time Magic Auth code and emails it to the user.
+func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOpts) (UserResponse, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/magic_auth/send",
+		c.Endpoint,
+	)
+
+	data, err := c.JSONEncode(opts)
+	if err != nil {
+		return UserResponse{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		endpoint,
+		bytes.NewBuffer(data),
+	)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return UserResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return UserResponse{}, err
+	}
+
+	var body UserResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// EnrollAuthFactor enrolls an authentication factor for the user.
+func (c *Client) EnrollAuthFactor(ctx context.Context, opts EnrollAuthFactorOpts) (AuthenticationResponse, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/users/%s/auth_factors",
+		c.Endpoint,
+		opts.User,
+	)
+
+	data, err := c.JSONEncode(opts)
+	if err != nil {
+		return AuthenticationResponse{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		endpoint,
+		bytes.NewBuffer(data),
+	)
+	if err != nil {
+		return AuthenticationResponse{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return AuthenticationResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return AuthenticationResponse{}, err
+	}
+
+	var body AuthenticationResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// ListAuthFactors lists the available authentication factors for the user.
+func (c *Client) ListAuthFactors(ctx context.Context, opts ListAuthFactorsOpts) (ListAuthFactorsResponse, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/users/%s/auth_factors",
+		c.Endpoint,
+		opts.User,
+	)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return ListAuthFactorsResponse{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return ListAuthFactorsResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return ListAuthFactorsResponse{}, err
+	}
+
+	var body ListAuthFactorsResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// GetOrganizationMembership returns details of an existing Organization Membership
+func (c *Client) GetOrganizationMembership(ctx context.Context, opts GetOrganizationMembershipOpts) (OrganizationMembership, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/organization_memberships/%s",
+		c.Endpoint,
+		opts.OrganizationMembershipID,
+	)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return OrganizationMembership{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return OrganizationMembership{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return OrganizationMembership{}, err
+	}
+
+	var body OrganizationMembership
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// List Organization Memberships matching the criteria specified.
+func (c *Client) ListOrganizationMemberships(ctx context.Context, opts ListOrganizationMembershipsOpts) (ListOrganizationMembershipsResponse, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/organization_memberships",
+		c.Endpoint,
+	)
+
+	req, err := http.NewRequest(
+		http.MethodGet,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return ListOrganizationMembershipsResponse{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	if opts.Limit == 0 {
+		opts.Limit = ResponseLimit
+	}
+
+	queryValues, err := query.Values(opts)
+	if err != nil {
+		return ListOrganizationMembershipsResponse{}, err
+	}
+
+	req.URL.RawQuery = queryValues.Encode()
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return ListOrganizationMembershipsResponse{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return ListOrganizationMembershipsResponse{}, err
+	}
+
+	var body ListOrganizationMembershipsResponse
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// Create an Organization Membership. Adds a User to an Organization.
+func (c *Client) CreateOrganizationMembership(ctx context.Context, opts CreateOrganizationMembershipOpts) (OrganizationMembership, error) {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/organization_memberships",
+		c.Endpoint,
+	)
+
+	data, err := c.JSONEncode(opts)
+	if err != nil {
+		return OrganizationMembership{}, err
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		endpoint,
+		bytes.NewBuffer(data),
+	)
+	if err != nil {
+		return OrganizationMembership{}, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return OrganizationMembership{}, err
+	}
+	defer res.Body.Close()
+
+	if err = workos_errors.TryGetHTTPError(res); err != nil {
+		return OrganizationMembership{}, err
+	}
+
+	var body OrganizationMembership
+	dec := json.NewDecoder(res.Body)
+	err = dec.Decode(&body)
+
+	return body, err
+}
+
+// Delete an Organization Membership. Removes the membership's User from its Organization.
+func (c *Client) DeleteOrganizationMembership(ctx context.Context, opts DeleteOrganizationMembershipOpts) error {
+	endpoint := fmt.Sprintf(
+		"%s/user_management/organization_memberships/%s",
+		c.Endpoint,
+		opts.OrganizationMembershipID,
+	)
+
+	req, err := http.NewRequest(
+		http.MethodDelete,
+		endpoint,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	return workos_errors.TryGetHTTPError(res)
+}

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v2/internal/workos"
-	"github.com/workos/workos-go/v2/pkg/common"
-	"github.com/workos/workos-go/v2/pkg/mfa"
-	"github.com/workos/workos-go/v2/pkg/workos_errors"
+	"github.com/workos/workos-go/v3/internal/workos"
+	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v3/pkg/mfa"
+	"github.com/workos/workos-go/v3/pkg/workos_errors"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v2/pkg/common"
-	"github.com/workos/workos-go/v2/pkg/mfa"
+	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v3/pkg/mfa"
 )
 
 func TestGetUser(t *testing.T) {

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -1,0 +1,1655 @@
+package usermanagement
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/workos/workos-go/v2/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/mfa"
+)
+
+func TestGetUser(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  GetUserOpts
+		expected User
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns a User",
+			client:   NewClient("test"),
+			options: GetUserOpts{
+				User: "user_123",
+			},
+			expected: User{
+				ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+				Email:         "marcelina@foo-corp.com",
+				FirstName:     "Marcelina",
+				LastName:      "Davis",
+				EmailVerified: true,
+				CreatedAt:     "2021-06-25T19:07:33.155Z",
+				UpdatedAt:     "2021-06-25T19:07:33.155Z",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(getUserTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.GetUser(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func getUserTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/users/user_123" {
+		body, err = json.Marshal(User{
+			ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+			Email:         "marcelina@foo-corp.com",
+			FirstName:     "Marcelina",
+			LastName:      "Davis",
+			EmailVerified: true,
+			CreatedAt:     "2021-06-25T19:07:33.155Z",
+			UpdatedAt:     "2021-06-25T19:07:33.155Z",
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestListUsers(t *testing.T) {
+	t.Run("ListUsers succeeds to fetch Users", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(listUsersTestHandler))
+		defer server.Close()
+		client := &Client{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			APIKey:     "test",
+		}
+
+		expectedResponse := ListUsersResponse{
+			Data: []User{
+				{
+					ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+					Email:         "marcelina@foo-corp.com",
+					FirstName:     "Marcelina",
+					LastName:      "Davis",
+					EmailVerified: true,
+					CreatedAt:     "2021-06-25T19:07:33.155Z",
+					UpdatedAt:     "2021-06-25T19:07:33.155Z",
+				},
+			},
+			ListMetadata: common.ListMetadata{
+				After: "",
+			},
+		}
+
+		users, err := client.ListUsers(context.Background(), ListUsersOpts{})
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResponse, users)
+	})
+
+	t.Run("ListUsers succeeds to fetch Users belonging to an Organization", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(listUsersTestHandler))
+		defer server.Close()
+		client := &Client{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			APIKey:     "test",
+		}
+
+		expectedResponse := ListUsersResponse{
+			Data: []User{
+				{
+					ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+					Email:         "marcelina@foo-corp.com",
+					FirstName:     "Marcelina",
+					LastName:      "Davis",
+					EmailVerified: true,
+					CreatedAt:     "2021-06-25T19:07:33.155Z",
+					UpdatedAt:     "2021-06-25T19:07:33.155Z",
+				},
+			},
+			ListMetadata: common.ListMetadata{
+				After: "",
+			},
+		}
+
+		users, err := client.ListUsers(context.Background(), ListUsersOpts{OrganizationID: "org_123"})
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResponse, users)
+	})
+
+	t.Run("ListUsers succeeds to fetch Users created after a timestamp", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(listUsersTestHandler))
+		defer server.Close()
+		client := &Client{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			APIKey:     "test",
+		}
+
+		currentTime := time.Now()
+		after := currentTime.AddDate(0, 0, -2)
+
+		params := ListUsersOpts{
+			After: after.String(),
+		}
+
+		expectedResponse := ListUsersResponse{
+			Data: []User{
+				{
+					ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+					Email:         "marcelina@foo-corp.com",
+					FirstName:     "Marcelina",
+					LastName:      "Davis",
+					EmailVerified: true,
+					CreatedAt:     "2021-06-25T19:07:33.155Z",
+					UpdatedAt:     "2021-06-25T19:07:33.155Z",
+				},
+			},
+			ListMetadata: common.ListMetadata{
+				After: "",
+			},
+		}
+
+		users, err := client.ListUsers(context.Background(), params)
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResponse, users)
+	})
+}
+
+func listUsersTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	body, err := json.Marshal(struct {
+		ListUsersResponse
+	}{
+		ListUsersResponse: ListUsersResponse{
+			Data: []User{
+				{
+					ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+					Email:         "marcelina@foo-corp.com",
+					FirstName:     "Marcelina",
+					LastName:      "Davis",
+					EmailVerified: true,
+					CreatedAt:     "2021-06-25T19:07:33.155Z",
+					UpdatedAt:     "2021-06-25T19:07:33.155Z",
+				},
+			},
+			ListMetadata: common.ListMetadata{
+				After: "",
+			},
+		},
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestCreateUser(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  CreateUserOpts
+		expected User
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns User",
+			client:   NewClient("test"),
+			options: CreateUserOpts{
+				Email:         "marcelina@gmail.com",
+				FirstName:     "Marcelina",
+				LastName:      "Davis",
+				EmailVerified: false,
+				Password:      "pass",
+			},
+			expected: User{
+				ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+				Email:         "marcelina@foo-corp.com",
+				FirstName:     "Marcelina",
+				LastName:      "Davis",
+				EmailVerified: true,
+				CreatedAt:     "2021-06-25T19:07:33.155Z",
+				UpdatedAt:     "2021-06-25T19:07:33.155Z",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(createUserTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.CreateUser(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func createUserTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/users" {
+		body, err = json.Marshal(User{
+			ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+			Email:         "marcelina@foo-corp.com",
+			FirstName:     "Marcelina",
+			LastName:      "Davis",
+			EmailVerified: true,
+			CreatedAt:     "2021-06-25T19:07:33.155Z",
+			UpdatedAt:     "2021-06-25T19:07:33.155Z",
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestUpdateUser(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  UpdateUserOpts
+		expected User
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns User",
+			client:   NewClient("test"),
+			options: UpdateUserOpts{
+				User:          "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+				FirstName:     "Marcelina",
+				LastName:      "Davis",
+				EmailVerified: false,
+			},
+			expected: User{
+				ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+				Email:         "marcelina@foo-corp.com",
+				FirstName:     "Marcelina",
+				LastName:      "Davis",
+				EmailVerified: true,
+				CreatedAt:     "2021-06-25T19:07:33.155Z",
+				UpdatedAt:     "2021-06-25T19:07:33.155Z",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(updateUserTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.UpdateUser(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func updateUserTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/users/user_01E3JC5F5Z1YJNPGVYWV9SX6GH" {
+		body, err = json.Marshal(User{
+			ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+			Email:         "marcelina@foo-corp.com",
+			FirstName:     "Marcelina",
+			LastName:      "Davis",
+			EmailVerified: true,
+			CreatedAt:     "2021-06-25T19:07:33.155Z",
+			UpdatedAt:     "2021-06-25T19:07:33.155Z",
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestDeleteUser(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  DeleteUserOpts
+		expected error
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns User",
+			client:   NewClient("test"),
+			options: DeleteUserOpts{
+				User: "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(deleteUserTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			err := client.DeleteUser(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, err)
+		})
+	}
+}
+
+func deleteUserTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/users/user_01E3JC5F5Z1YJNPGVYWV9SX6GH" {
+		body, err = nil, nil
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestAuthenticateUserWithPassword(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  AuthenticateWithPasswordOpts
+		expected UserResponse
+		err      bool
+	}{{
+		scenario: "Request without API Key returns an error",
+		client:   NewClient(""),
+		err:      true,
+	},
+		{
+			scenario: "Request returns an AuthenticationResponse",
+			client:   NewClient("test"),
+			options: AuthenticateWithPasswordOpts{
+				ClientID: "project_123",
+				Email:    "employee@foo-corp.com",
+				Password: "test_123",
+			},
+			expected: UserResponse{
+				User: User{
+					ID:        "testUserID",
+					FirstName: "John",
+					LastName:  "Doe",
+					Email:     "employee@foo-corp.com",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(authenticationResponseTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			response, err := client.AuthenticateWithPassword(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, response)
+		})
+	}
+}
+
+func TestAuthenticateUserWithCode(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  AuthenticateWithCodeOpts
+		expected UserResponse
+		err      bool
+	}{{
+		scenario: "Request without API Key returns an error",
+		client:   NewClient(""),
+		err:      true,
+	},
+		{
+			scenario: "Request returns an AuthenticationResponse",
+			client:   NewClient("test"),
+			options: AuthenticateWithCodeOpts{
+				ClientID: "project_123",
+				Code:     "test_123",
+			},
+			expected: UserResponse{
+				User: User{
+					ID:        "testUserID",
+					FirstName: "John",
+					LastName:  "Doe",
+					Email:     "employee@foo-corp.com",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(authenticationResponseTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			response, err := client.AuthenticateWithCode(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, response)
+		})
+	}
+}
+
+func TestAuthenticateUserWithMagicAuth(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  AuthenticateWithMagicAuthOpts
+		expected UserResponse
+		err      bool
+	}{{
+		scenario: "Request without API Key returns an error",
+		client:   NewClient(""),
+		err:      true,
+	},
+		{
+			scenario: "Request returns an AuthenticationResponse",
+			client:   NewClient("test"),
+			options: AuthenticateWithMagicAuthOpts{
+				ClientID: "project_123",
+				Code:     "test_123",
+				User:     "user_123",
+			},
+			expected: UserResponse{
+				User: User{
+					ID:        "testUserID",
+					FirstName: "John",
+					LastName:  "Doe",
+					Email:     "employee@foo-corp.com",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(authenticationResponseTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			response, err := client.AuthenticateWithMagicAuth(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, response)
+		})
+	}
+}
+
+func TestAuthenticateUserWithTOTP(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  AuthenticateWithTOTPOpts
+		expected UserResponse
+		err      bool
+	}{{
+		scenario: "Request without API Key returns an error",
+		client:   NewClient(""),
+		err:      true,
+	},
+		{
+			scenario: "Request returns an AuthenticationResponse",
+			client:   NewClient("test"),
+			options: AuthenticateWithTOTPOpts{
+				ClientID:                   "project_123",
+				Code:                       "test_123",
+				PendingAuthenticationToken: "cTDQJTTkTkkVYxQUlKBIxEsFs",
+				AuthenticationChallengeID:  "auth_challenge_01H96FETXGTW1QMBSBT2T36PW0",
+			},
+			expected: UserResponse{
+				User: User{
+					ID:        "testUserID",
+					FirstName: "John",
+					LastName:  "Doe",
+					Email:     "employee@foo-corp.com",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(authenticationResponseTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			response, err := client.AuthenticateWithTOTP(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, response)
+		})
+	}
+}
+
+func authenticationResponseTestHandler(w http.ResponseWriter, r *http.Request) {
+
+	payload := make(map[string]interface{})
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if secret, exists := payload["client_secret"].(string); exists && secret != "" {
+		response := UserResponse{
+			User: User{
+				ID:        "testUserID",
+				FirstName: "John",
+				LastName:  "Doe",
+				Email:     "employee@foo-corp.com",
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	w.WriteHeader(http.StatusUnauthorized)
+}
+
+func TestSendVerificationEmail(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  SendVerificationEmailOpts
+		expected UserResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns User",
+			client:   NewClient("test"),
+			options: SendVerificationEmailOpts{
+				User: "user_123",
+			},
+			expected: UserResponse{
+				User: User{
+					ID:            "user_123",
+					Email:         "marcelina@foo-corp.com",
+					FirstName:     "Marcelina",
+					LastName:      "Davis",
+					EmailVerified: true,
+					CreatedAt:     "2021-06-25T19:07:33.155Z",
+					UpdatedAt:     "2021-06-25T19:07:33.155Z",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(sendVerificationEmailTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.SendVerificationEmail(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func sendVerificationEmailTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/users/user_123/email_verification/send" {
+		body, err = json.Marshal(UserResponse{
+			User: User{
+				ID: "user_123",
+
+				Email:         "marcelina@foo-corp.com",
+				FirstName:     "Marcelina",
+				LastName:      "Davis",
+				EmailVerified: true,
+				CreatedAt:     "2021-06-25T19:07:33.155Z",
+				UpdatedAt:     "2021-06-25T19:07:33.155Z",
+			},
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestVerifyEmail(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  VerifyEmailOpts
+		expected UserResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns User",
+			client:   NewClient("test"),
+			options: VerifyEmailOpts{
+				User: "user_123",
+				Code: "testToken",
+			},
+			expected: UserResponse{
+				User: User{
+					ID:            "user_123",
+					Email:         "marcelina@foo-corp.com",
+					FirstName:     "Marcelina",
+					LastName:      "Davis",
+					EmailVerified: true,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(verifyEmailCodeTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.VerifyEmail(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func verifyEmailCodeTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/users/user_123/email_verification/confirm" {
+		body, err = json.Marshal(UserResponse{
+			User: User{
+				ID:            "user_123",
+				Email:         "marcelina@foo-corp.com",
+				FirstName:     "Marcelina",
+				LastName:      "Davis",
+				EmailVerified: true,
+			},
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestSendPasswordResetEmail(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  SendPasswordResetEmailOpts
+		expected UserResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns User",
+			client:   NewClient("test"),
+			options: SendPasswordResetEmailOpts{
+				Email:            "marcelina@foo-corp.com",
+				PasswordResetUrl: "https://foo-corp.com/reset-password",
+			},
+			expected: UserResponse{
+				User: User{
+					ID:            "user_123",
+					Email:         "marcelina@foo-corp.com",
+					FirstName:     "Marcelina",
+					LastName:      "Davis",
+					EmailVerified: true,
+					CreatedAt:     "2021-06-25T19:07:33.155Z",
+					UpdatedAt:     "2021-06-25T19:07:33.155Z",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(sendPasswordResetEmailTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.SendPasswordResetEmail(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func sendPasswordResetEmailTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/password_reset/send" {
+		body, err = json.Marshal(UserResponse{
+			User: User{
+				ID:            "user_123",
+				Email:         "marcelina@foo-corp.com",
+				FirstName:     "Marcelina",
+				LastName:      "Davis",
+				EmailVerified: true,
+				CreatedAt:     "2021-06-25T19:07:33.155Z",
+				UpdatedAt:     "2021-06-25T19:07:33.155Z",
+			},
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestResetPassword(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  ResetPasswordOpts
+		expected UserResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns User",
+			client:   NewClient("test"),
+			options: ResetPasswordOpts{
+				Token: "testToken",
+			},
+			expected: UserResponse{
+				User: User{
+					ID: "user_123",
+
+					Email:         "marcelina@foo-corp.com",
+					FirstName:     "Marcelina",
+					LastName:      "Davis",
+					EmailVerified: true,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(resetPasswordHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.ResetPassword(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func resetPasswordHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/password_reset/confirm" {
+		body, err = json.Marshal(UserResponse{
+			User: User{
+				ID: "user_123",
+
+				Email:         "marcelina@foo-corp.com",
+				FirstName:     "Marcelina",
+				LastName:      "Davis",
+				EmailVerified: true,
+			},
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestSendMagicAuthCode(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  SendMagicAuthCodeOpts
+		expected UserResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns User",
+			client:   NewClient("test"),
+			options: SendMagicAuthCodeOpts{
+				Email: "marcelina@foo-corp.com",
+			},
+			expected: UserResponse{
+				User: User{
+					ID:        "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+					Email:     "marcelina@foo-corp.com",
+					FirstName: "Marcelina",
+					LastName:  "Davis",
+					CreatedAt: "2021-06-25T19:07:33.155Z",
+					UpdatedAt: "2021-06-25T19:07:33.155Z",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(sendMagicAuthCodeTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.SendMagicAuthCode(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func sendMagicAuthCodeTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/magic_auth/send" {
+		body, err = json.Marshal(UserResponse{
+			User: User{
+				ID:        "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+				Email:     "marcelina@foo-corp.com",
+				FirstName: "Marcelina",
+				LastName:  "Davis",
+				CreatedAt: "2021-06-25T19:07:33.155Z",
+				UpdatedAt: "2021-06-25T19:07:33.155Z",
+			},
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestEnrollAuthFactor(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  EnrollAuthFactorOpts
+		expected AuthenticationResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns User",
+			client:   NewClient("test"),
+			options: EnrollAuthFactorOpts{
+				User: "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+				Type: mfa.TOTP,
+			},
+			expected: AuthenticationResponse{
+				Factor: mfa.Factor{
+					ID:        "auth_factor_test123",
+					CreatedAt: "2022-02-17T22:39:26.616Z",
+					UpdatedAt: "2022-02-17T22:39:26.616Z",
+					Type:      "generic_otp",
+				},
+				Challenge: mfa.Challenge{
+					ID:        "auth_challenge_test123",
+					CreatedAt: "2022-02-17T22:39:26.616Z",
+					UpdatedAt: "2022-02-17T22:39:26.616Z",
+					FactorID:  "auth_factor_test123",
+					ExpiresAt: "2022-02-17T22:39:26.616Z",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(enrollAuthFactorTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.EnrollAuthFactor(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func enrollAuthFactorTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/users/user_01E3JC5F5Z1YJNPGVYWV9SX6GH/auth_factors" {
+		body, err = json.Marshal(AuthenticationResponse{
+			Factor: mfa.Factor{
+				ID:        "auth_factor_test123",
+				CreatedAt: "2022-02-17T22:39:26.616Z",
+				UpdatedAt: "2022-02-17T22:39:26.616Z",
+				Type:      "generic_otp",
+			},
+			Challenge: mfa.Challenge{
+				ID:        "auth_challenge_test123",
+				CreatedAt: "2022-02-17T22:39:26.616Z",
+				UpdatedAt: "2022-02-17T22:39:26.616Z",
+				FactorID:  "auth_factor_test123",
+				ExpiresAt: "2022-02-17T22:39:26.616Z",
+			},
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestListAuthFactor(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  ListAuthFactorsOpts
+		expected ListAuthFactorsResponse
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns User",
+			client:   NewClient("test"),
+			options: ListAuthFactorsOpts{
+				User: "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+			},
+			expected: ListAuthFactorsResponse{
+				Data: []mfa.Factor{
+					{
+						ID:        "auth_factor_test123",
+						CreatedAt: "2022-02-17T22:39:26.616Z",
+						UpdatedAt: "2022-02-17T22:39:26.616Z",
+						Type:      "generic_otp",
+					},
+					{
+						ID:        "auth_factor_test234",
+						CreatedAt: "2022-02-17T22:39:26.616Z",
+						UpdatedAt: "2022-02-17T22:39:26.616Z",
+						Type:      "generic_otp",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(listAuthFactorsTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.ListAuthFactors(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func listAuthFactorsTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/users/user_01E3JC5F5Z1YJNPGVYWV9SX6GH/auth_factors" {
+		body, err = json.Marshal(ListAuthFactorsResponse{
+			Data: []mfa.Factor{
+				{
+					ID:        "auth_factor_test123",
+					CreatedAt: "2022-02-17T22:39:26.616Z",
+					UpdatedAt: "2022-02-17T22:39:26.616Z",
+					Type:      "generic_otp",
+				},
+				{
+					ID:        "auth_factor_test234",
+					CreatedAt: "2022-02-17T22:39:26.616Z",
+					UpdatedAt: "2022-02-17T22:39:26.616Z",
+					Type:      "generic_otp",
+				},
+			},
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestGetOrganizationMembership(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  GetOrganizationMembershipOpts
+		expected OrganizationMembership
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns an Organization Membership",
+			client:   NewClient("test"),
+			options: GetOrganizationMembershipOpts{
+				OrganizationMembershipID: "om_01E4ZCR3C56J083X43JQXF3JK5",
+			},
+			expected: OrganizationMembership{
+				ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+				UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+				OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+				CreatedAt:      "2021-06-25T19:07:33.155Z",
+				UpdatedAt:      "2021-06-25T19:07:33.155Z",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(getOrganizationMembershipTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			organizationMembership, err := client.GetOrganizationMembership(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, organizationMembership)
+		})
+	}
+}
+
+func getOrganizationMembershipTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/organization_memberships/om_01E4ZCR3C56J083X43JQXF3JK5" {
+		body, err = json.Marshal(OrganizationMembership{
+			ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+			UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+			OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+			CreatedAt:      "2021-06-25T19:07:33.155Z",
+			UpdatedAt:      "2021-06-25T19:07:33.155Z",
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestListOrganizationMemberships(t *testing.T) {
+	t.Run("ListOrganizationMemberships succeeds to fetch OrganizationMemberships belonging to an Organization", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(listOrganizationMembershipsTestHandler))
+		defer server.Close()
+		client := &Client{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			APIKey:     "test",
+		}
+
+		expectedResponse := ListOrganizationMembershipsResponse{
+			Data: []OrganizationMembership{
+				{
+					ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+					UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+					OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+					CreatedAt:      "2021-06-25T19:07:33.155Z",
+					UpdatedAt:      "2021-06-25T19:07:33.155Z",
+				},
+			},
+			ListMetadata: common.ListMetadata{
+				After: "",
+			},
+		}
+
+		organizationMemberships, err := client.ListOrganizationMemberships(
+			context.Background(),
+			ListOrganizationMembershipsOpts{OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5"},
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResponse, organizationMemberships)
+	})
+
+	t.Run("ListOrganizationMemberships succeeds to fetch OrganizationMemberships belonging to a User", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(listOrganizationMembershipsTestHandler))
+		defer server.Close()
+		client := &Client{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			APIKey:     "test",
+		}
+
+		expectedResponse := ListOrganizationMembershipsResponse{
+			Data: []OrganizationMembership{
+				{
+					ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+					UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+					OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+					CreatedAt:      "2021-06-25T19:07:33.155Z",
+					UpdatedAt:      "2021-06-25T19:07:33.155Z",
+				},
+			},
+			ListMetadata: common.ListMetadata{
+				After: "",
+			},
+		}
+
+		organizationMemberships, err := client.ListOrganizationMemberships(
+			context.Background(),
+			ListOrganizationMembershipsOpts{UserID: "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E"},
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResponse, organizationMemberships)
+	})
+}
+
+func listOrganizationMembershipsTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "workos-go/") {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/organization_memberships" {
+		body, err = json.Marshal(struct {
+			ListOrganizationMembershipsResponse
+		}{
+			ListOrganizationMembershipsResponse: ListOrganizationMembershipsResponse{
+				Data: []OrganizationMembership{
+					{
+						ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+						UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+						OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+						CreatedAt:      "2021-06-25T19:07:33.155Z",
+						UpdatedAt:      "2021-06-25T19:07:33.155Z",
+					},
+				},
+				ListMetadata: common.ListMetadata{
+					After: "",
+				},
+			},
+		})
+	}
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestCreateOrganizationMembership(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  CreateOrganizationMembershipOpts
+		expected OrganizationMembership
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns OrganizationMembership",
+			client:   NewClient("test"),
+			options: CreateOrganizationMembershipOpts{
+				UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+				OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+			},
+			expected: OrganizationMembership{
+				ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+				UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+				OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+				CreatedAt:      "2021-06-25T19:07:33.155Z",
+				UpdatedAt:      "2021-06-25T19:07:33.155Z",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(createOrganizationMembershipTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			user, err := client.CreateOrganizationMembership(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, user)
+		})
+	}
+}
+
+func createOrganizationMembershipTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/organization_memberships" {
+		body, err = json.Marshal(OrganizationMembership{
+			ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+			UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+			OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+			CreatedAt:      "2021-06-25T19:07:33.155Z",
+			UpdatedAt:      "2021-06-25T19:07:33.155Z",
+		})
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func TestDeleteOrganizationMembership(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  DeleteOrganizationMembershipOpts
+		expected error
+		err      bool
+	}{
+		{
+			scenario: "Request without API Key returns an error",
+			client:   NewClient(""),
+			err:      true,
+		},
+		{
+			scenario: "Request returns OrganizationMembership",
+			client:   NewClient("test"),
+			options: DeleteOrganizationMembershipOpts{
+				OrganizationMembershipID: "om_01E4ZCR3C56J083X43JQXF3JK5",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(deleteOrganizationMembershipTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			err := client.DeleteOrganizationMembership(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, err)
+		})
+	}
+}
+
+func deleteOrganizationMembershipTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	var err error
+
+	if r.URL.Path == "/user_management/organization_memberships/om_01E4ZCR3C56J083X43JQXF3JK5" {
+		body, err = nil, nil
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -1,0 +1,202 @@
+// Package `usermanagement` provides a client wrapping the WorkOS User Management API.
+package usermanagement
+
+import (
+	"context"
+	"net/http"
+)
+
+var (
+	// DefaultClient is the client used by User management methods
+	DefaultClient = NewClient("")
+)
+
+// Client represents a client that fetch User Management data from WorkOS API.
+type Client struct {
+	// The WorkOS api key. It can be found in
+	// https://dashboard.workos.com/api-keys.
+	//
+	// REQUIRED.
+	APIKey string
+
+	// The http.Client that is used to send request to WorkOS.
+	//
+	// Defaults to http.Client.
+	HTTPClient *http.Client
+
+	// The endpoint to WorkOS API.
+	//
+	// Defaults to https://api.workos.com.
+	Endpoint string
+
+	// The function used to encode in JSON. Defaults to json.Marshal.
+	JSONEncode func(v interface{}) ([]byte, error)
+}
+
+// SetAPIKey configures the default client that is used by the User management methods
+// It must be called before using those functions.
+func SetAPIKey(apiKey string) {
+	DefaultClient.APIKey = apiKey
+}
+
+// GetUser gets a User.
+func GetUser(
+	ctx context.Context,
+	opts GetUserOpts,
+) (User, error) {
+	return DefaultClient.GetUser(ctx, opts)
+}
+
+// ListUsers gets a list of Users.
+func ListUsers(
+	ctx context.Context,
+	opts ListUsersOpts,
+) (ListUsersResponse, error) {
+	return DefaultClient.ListUsers(ctx, opts)
+}
+
+// CreateUser creates a User.
+func CreateUser(
+	ctx context.Context,
+	opts CreateUserOpts,
+) (User, error) {
+	return DefaultClient.CreateUser(ctx, opts)
+}
+
+// UpdateUser creates a User.
+func UpdateUser(
+	ctx context.Context,
+	opts UpdateUserOpts,
+) (User, error) {
+	return DefaultClient.UpdateUser(ctx, opts)
+}
+
+// DeleteUser deletes a existing User.
+func DeleteUser(
+	ctx context.Context,
+	opts DeleteUserOpts,
+) error {
+	return DefaultClient.DeleteUser(ctx, opts)
+}
+
+// AuthenticateWithPassword authenticates a user with email and password and optionally creates a session.
+func AuthenticateWithPassword(
+	ctx context.Context,
+	opts AuthenticateWithPasswordOpts,
+) (UserResponse, error) {
+	return DefaultClient.AuthenticateWithPassword(ctx, opts)
+}
+
+// AuthenticateWithCode authenticates an OAuth user or a managed SSO user that is logging in through SSO, and
+// optionally creates a session.
+func AuthenticateWithCode(
+	ctx context.Context,
+	opts AuthenticateWithCodeOpts,
+) (UserResponse, error) {
+	return DefaultClient.AuthenticateWithCode(ctx, opts)
+}
+
+// AuthenticateWithMagicAuth authenticates a user by verifying a one-time code sent to the user's email address by
+// the Magic Auth Send Code endpoint.
+func AuthenticateWithMagicAuth(
+	ctx context.Context,
+	opts AuthenticateWithMagicAuthOpts,
+) (UserResponse, error) {
+	return DefaultClient.AuthenticateWithMagicAuth(ctx, opts)
+}
+
+// AuthenticateWithTOTP authenticates a user by verifying a time-based one-time password (TOTP)
+func AuthenticateWithTOTP(
+	ctx context.Context,
+	opts AuthenticateWithTOTPOpts,
+) (UserResponse, error) {
+	return DefaultClient.AuthenticateWithTOTP(ctx, opts)
+}
+
+// SendVerificationEmail creates an email verification challenge and emails verification token to user.
+func SendVerificationEmail(
+	ctx context.Context,
+	opts SendVerificationEmailOpts,
+) (UserResponse, error) {
+	return DefaultClient.SendVerificationEmail(ctx, opts)
+}
+
+// VerifyEmail verifies a user's email using the verification token that was sent to the user.
+func VerifyEmail(
+	ctx context.Context,
+	opts VerifyEmailOpts,
+) (UserResponse, error) {
+	return DefaultClient.VerifyEmail(ctx, opts)
+}
+
+// SendPasswordResetEmail creates a password reset challenge and emails a password reset link to an unmanaged user.
+func SendPasswordResetEmail(
+	ctx context.Context,
+	opts SendPasswordResetEmailOpts,
+) (UserResponse, error) {
+	return DefaultClient.SendPasswordResetEmail(ctx, opts)
+}
+
+// ResetPassword resets user password using token that was sent to the user.
+func ResetPassword(
+	ctx context.Context,
+	opts ResetPasswordOpts,
+) (UserResponse, error) {
+	return DefaultClient.ResetPassword(ctx, opts)
+}
+
+// SendMagicAuthCode sends a one-time code to the user's email address.
+func SendMagicAuthCode(
+	ctx context.Context,
+	opts SendMagicAuthCodeOpts,
+) (UserResponse, error) {
+	return DefaultClient.SendMagicAuthCode(ctx, opts)
+}
+
+// EnrollAuthFactor enrolls an authentication factor for the user.
+func EnrollAuthFactor(
+	ctx context.Context,
+	opts EnrollAuthFactorOpts,
+) (AuthenticationResponse, error) {
+	return DefaultClient.EnrollAuthFactor(ctx, opts)
+}
+
+// ListAuthFactors lists the available authentication factors for the user.
+func ListAuthFactors(
+	ctx context.Context,
+	opts ListAuthFactorsOpts,
+) (ListAuthFactorsResponse, error) {
+	return DefaultClient.ListAuthFactors(ctx, opts)
+}
+
+// GetOrganizationMembership gets an OrganizationMembership.
+func GetOrganizationMembership(
+	ctx context.Context,
+	opts GetOrganizationMembershipOpts,
+) (OrganizationMembership, error) {
+	return DefaultClient.GetOrganizationMembership(ctx, opts)
+}
+
+// ListOrganizationMemberships gets a list of OrganizationMemberhips.
+func ListOrganizationMemberships(
+	ctx context.Context,
+	opts ListOrganizationMembershipsOpts,
+) (ListOrganizationMembershipsResponse, error) {
+	return DefaultClient.ListOrganizationMemberships(ctx, opts)
+}
+
+// CreateOrganizationMembership creates a OrganizationMembership.
+func CreateOrganizationMembership(
+	ctx context.Context,
+	opts CreateOrganizationMembershipOpts,
+) (OrganizationMembership, error) {
+	return DefaultClient.CreateOrganizationMembership(ctx, opts)
+}
+
+// DeleteOrganizationMembership deletes a existing OrganizationMembership.
+func DeleteOrganizationMembership(
+	ctx context.Context,
+	opts DeleteOrganizationMembershipOpts,
+) error {
+	return DefaultClient.DeleteOrganizationMembership(ctx, opts)
+}

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/workos/workos-go/v2/pkg/common"
-	"github.com/workos/workos-go/v2/pkg/mfa"
+	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v3/pkg/mfa"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -1,0 +1,549 @@
+package usermanagement
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/workos/workos-go/v2/pkg/common"
+	"github.com/workos/workos-go/v2/pkg/mfa"
+
+	"github.com/stretchr/testify/require"
+)
+
+func mockClient(s *httptest.Server) *Client {
+	client := NewClient("")
+	client.HTTPClient = s.Client()
+	client.Endpoint = s.URL
+	return client
+}
+
+func TestUserManagementGetUser(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getUserTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := User{
+		ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+		Email:         "marcelina@foo-corp.com",
+		FirstName:     "Marcelina",
+		LastName:      "Davis",
+		EmailVerified: true,
+		CreatedAt:     "2021-06-25T19:07:33.155Z",
+		UpdatedAt:     "2021-06-25T19:07:33.155Z",
+	}
+
+	userRes, err := GetUser(context.Background(), GetUserOpts{
+		User: "user_123",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUserManagementListUsers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(listUsersTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := ListUsersResponse{
+		Data: []User{
+			{
+				ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+				Email:         "marcelina@foo-corp.com",
+				FirstName:     "Marcelina",
+				LastName:      "Davis",
+				EmailVerified: true,
+				CreatedAt:     "2021-06-25T19:07:33.155Z",
+				UpdatedAt:     "2021-06-25T19:07:33.155Z",
+			},
+		},
+		ListMetadata: common.ListMetadata{
+			After: "",
+		},
+	}
+
+	userRes, err := ListUsers(context.Background(), ListUsersOpts{})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUserManagementCreateUser(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(createUserTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := User{
+		ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+		Email:         "marcelina@foo-corp.com",
+		FirstName:     "Marcelina",
+		LastName:      "Davis",
+		EmailVerified: true,
+		CreatedAt:     "2021-06-25T19:07:33.155Z",
+		UpdatedAt:     "2021-06-25T19:07:33.155Z",
+	}
+
+	userRes, err := CreateUser(context.Background(), CreateUserOpts{
+		Email:         "marcelina@gmail.com",
+		FirstName:     "Marcelina",
+		LastName:      "Davis",
+		EmailVerified: true,
+		Password:      "pass",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUserManagementUpdateUser(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(updateUserTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := User{
+		ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+		Email:         "marcelina@foo-corp.com",
+		FirstName:     "Marcelina",
+		LastName:      "Davis",
+		EmailVerified: true,
+		CreatedAt:     "2021-06-25T19:07:33.155Z",
+		UpdatedAt:     "2021-06-25T19:07:33.155Z",
+	}
+
+	userRes, err := UpdateUser(context.Background(), UpdateUserOpts{
+		User:          "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+		FirstName:     "Marcelina",
+		LastName:      "Davis",
+		EmailVerified: true,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUsersDeleteUser(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(deleteUserTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	err := DeleteUser(context.Background(), DeleteUserOpts{
+		User: "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, nil, err)
+}
+
+func TestUsersSendVerificationEmail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(sendVerificationEmailTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := UserResponse{
+		User: User{
+			ID:            "user_123",
+			Email:         "marcelina@foo-corp.com",
+			FirstName:     "Marcelina",
+			LastName:      "Davis",
+			EmailVerified: true,
+			CreatedAt:     "2021-06-25T19:07:33.155Z",
+			UpdatedAt:     "2021-06-25T19:07:33.155Z",
+		},
+	}
+
+	userRes, err := SendVerificationEmail(context.Background(), SendVerificationEmailOpts{
+		User: "user_123",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUserManagementVerifyEmail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(verifyEmailCodeTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := UserResponse{
+		User: User{
+			ID:            "user_123",
+			Email:         "marcelina@foo-corp.com",
+			FirstName:     "Marcelina",
+			LastName:      "Davis",
+			EmailVerified: true,
+		},
+	}
+
+	userRes, err := VerifyEmail(context.Background(), VerifyEmailOpts{
+		User: "user_123",
+		Code: "testToken",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUserManagementCreatePasswordResetChallenge(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(sendPasswordResetEmailTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := UserResponse{
+		User: User{
+			ID:            "user_123",
+			Email:         "marcelina@foo-corp.com",
+			FirstName:     "Marcelina",
+			LastName:      "Davis",
+			EmailVerified: true,
+			CreatedAt:     "2021-06-25T19:07:33.155Z",
+			UpdatedAt:     "2021-06-25T19:07:33.155Z",
+		},
+	}
+
+	userRes, err := SendPasswordResetEmail(context.Background(), SendPasswordResetEmailOpts{
+		Email:            "marcelina@foo-corp.com",
+		PasswordResetUrl: "https://example.com/reset",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUserManagementResetPassword(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(resetPasswordHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := UserResponse{
+		User: User{
+			ID: "user_123",
+
+			Email:         "marcelina@foo-corp.com",
+			FirstName:     "Marcelina",
+			LastName:      "Davis",
+			EmailVerified: true,
+		},
+	}
+
+	userRes, err := ResetPassword(context.Background(), ResetPasswordOpts{
+		Token: "testToken",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUserManagementAuthenticateWithCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(authenticationResponseTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := UserResponse{
+		User: User{
+			ID:        "testUserID",
+			FirstName: "John",
+			LastName:  "Doe",
+			Email:     "employee@foo-corp.com",
+		},
+	}
+
+	authenticationRes, err := AuthenticateWithCode(context.Background(), AuthenticateWithCodeOpts{})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, authenticationRes)
+}
+
+func TestUserManagementAuthenticateWithPassword(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(authenticationResponseTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := UserResponse{
+		User: User{
+			ID:        "testUserID",
+			FirstName: "John",
+			LastName:  "Doe",
+			Email:     "employee@foo-corp.com",
+		},
+	}
+
+	authenticationRes, err := AuthenticateWithPassword(context.Background(), AuthenticateWithPasswordOpts{})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, authenticationRes)
+}
+
+func TestUserManagementAuthenticateWithMagicAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(authenticationResponseTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := UserResponse{
+		User: User{
+			ID:        "testUserID",
+			FirstName: "John",
+			LastName:  "Doe",
+			Email:     "employee@foo-corp.com",
+		},
+	}
+
+	authenticationRes, err := AuthenticateWithMagicAuth(context.Background(), AuthenticateWithMagicAuthOpts{})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, authenticationRes)
+}
+
+func TestUserManagementAuthenticateWithTOTP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(authenticationResponseTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := UserResponse{
+		User: User{
+			ID:        "testUserID",
+			FirstName: "John",
+			LastName:  "Doe",
+			Email:     "employee@foo-corp.com",
+		},
+	}
+
+	authenticationRes, err := AuthenticateWithTOTP(context.Background(), AuthenticateWithTOTPOpts{})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, authenticationRes)
+}
+
+func TestUserManagementSendMagicAuthCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(sendMagicAuthCodeTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := UserResponse{
+		User: User{
+			ID:        "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+			Email:     "marcelina@foo-corp.com",
+			FirstName: "Marcelina",
+			LastName:  "Davis",
+			CreatedAt: "2021-06-25T19:07:33.155Z",
+			UpdatedAt: "2021-06-25T19:07:33.155Z",
+		},
+	}
+
+	authenticationRes, err := SendMagicAuthCode(context.Background(), SendMagicAuthCodeOpts{})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, authenticationRes)
+}
+
+func TestUserManagementEnrollAuthFactor(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(enrollAuthFactorTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := AuthenticationResponse{
+		Factor: mfa.Factor{
+			ID:        "auth_factor_test123",
+			CreatedAt: "2022-02-17T22:39:26.616Z",
+			UpdatedAt: "2022-02-17T22:39:26.616Z",
+			Type:      "generic_otp",
+		},
+		Challenge: mfa.Challenge{
+			ID:        "auth_challenge_test123",
+			CreatedAt: "2022-02-17T22:39:26.616Z",
+			UpdatedAt: "2022-02-17T22:39:26.616Z",
+			FactorID:  "auth_factor_test123",
+			ExpiresAt: "2022-02-17T22:39:26.616Z",
+		},
+	}
+
+	authenticationRes, err := EnrollAuthFactor(context.Background(), EnrollAuthFactorOpts{
+		User: "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+		Type: mfa.TOTP,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, authenticationRes)
+}
+
+func TestUserManagementListAuthFactors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(listAuthFactorsTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := ListAuthFactorsResponse{
+		Data: []mfa.Factor{
+			{
+				ID:        "auth_factor_test123",
+				CreatedAt: "2022-02-17T22:39:26.616Z",
+				UpdatedAt: "2022-02-17T22:39:26.616Z",
+				Type:      "generic_otp",
+			},
+			{
+				ID:        "auth_factor_test234",
+				CreatedAt: "2022-02-17T22:39:26.616Z",
+				UpdatedAt: "2022-02-17T22:39:26.616Z",
+				Type:      "generic_otp",
+			},
+		},
+	}
+
+	authenticationRes, err := ListAuthFactors(context.Background(), ListAuthFactorsOpts{
+		User: "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, authenticationRes)
+}
+
+func TestUserManagementGetOrganizationMembership(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getOrganizationMembershipTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := OrganizationMembership{
+		ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+		UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+		OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+		CreatedAt:      "2021-06-25T19:07:33.155Z",
+		UpdatedAt:      "2021-06-25T19:07:33.155Z",
+	}
+
+	userRes, err := GetOrganizationMembership(context.Background(), GetOrganizationMembershipOpts{
+		OrganizationMembershipID: "om_01E4ZCR3C56J083X43JQXF3JK5",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUserManagementListOrganizationMemberships(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(listOrganizationMembershipsTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := ListOrganizationMembershipsResponse{
+		Data: []OrganizationMembership{
+			{
+				ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+				UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+				OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+				CreatedAt:      "2021-06-25T19:07:33.155Z",
+				UpdatedAt:      "2021-06-25T19:07:33.155Z",
+			},
+		},
+		ListMetadata: common.ListMetadata{
+			After: "",
+		},
+	}
+
+	userRes, err := ListOrganizationMemberships(context.Background(), ListOrganizationMembershipsOpts{})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUserManagementCreateOrganizationMembership(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(createOrganizationMembershipTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := OrganizationMembership{
+		ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+		UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+		OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+		CreatedAt:      "2021-06-25T19:07:33.155Z",
+		UpdatedAt:      "2021-06-25T19:07:33.155Z",
+	}
+
+	userRes, err := CreateOrganizationMembership(context.Background(), CreateOrganizationMembershipOpts{
+		UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+		OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
+func TestUsersDeleteOrganizationMembership(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(deleteOrganizationMembershipTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	err := DeleteOrganizationMembership(context.Background(), DeleteOrganizationMembershipOpts{
+		OrganizationMembershipID: "om_01E4ZCR3C56J083X43JQXF3JK5",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, nil, err)
+}


### PR DESCRIPTION
## Description
This is a partial revert of https://github.com/workos/workos-go/pull/279, where we removed the incomplete `usermanagement` package for the initial v3 major release.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
