### PR TITLE
Rename AuthenticationResponse -> EnrollAuthFactorResponse

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -170,11 +170,6 @@ type AuthenticateWithTOTPOpts struct {
 	AuthenticationChallengeID  string `json:"authentication_challenge_id"`
 }
 
-type AuthenticationResponse struct {
-	Factor    mfa.Factor    `json:"authentication_factor"`
-	Challenge mfa.Challenge `json:"authentication_challenge"`
-}
-
 type SendVerificationEmailOpts struct {
 	// The unique ID of the User who will be sent a verification email.
 	User string
@@ -217,6 +212,11 @@ type EnrollAuthFactorOpts struct {
 	Type       mfa.FactorType `json:"type"`
 	TOTPIssuer string         `json:"totp_issuer,omitempty"`
 	TOTPUser   string         `json:"totp_user,omitempty"`
+}
+
+type EnrollAuthFactorResponse struct {
+	Factor    mfa.Factor    `json:"authentication_factor"`
+	Challenge mfa.Challenge `json:"authentication_challenge"`
 }
 
 type ListAuthFactorsOpts struct {
@@ -899,7 +899,7 @@ func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOp
 }
 
 // EnrollAuthFactor enrolls an authentication factor for the user.
-func (c *Client) EnrollAuthFactor(ctx context.Context, opts EnrollAuthFactorOpts) (AuthenticationResponse, error) {
+func (c *Client) EnrollAuthFactor(ctx context.Context, opts EnrollAuthFactorOpts) (EnrollAuthFactorResponse, error) {
 	endpoint := fmt.Sprintf(
 		"%s/user_management/users/%s/auth_factors",
 		c.Endpoint,
@@ -908,7 +908,7 @@ func (c *Client) EnrollAuthFactor(ctx context.Context, opts EnrollAuthFactorOpts
 
 	data, err := c.JSONEncode(opts)
 	if err != nil {
-		return AuthenticationResponse{}, err
+		return EnrollAuthFactorResponse{}, err
 	}
 
 	req, err := http.NewRequest(
@@ -917,7 +917,7 @@ func (c *Client) EnrollAuthFactor(ctx context.Context, opts EnrollAuthFactorOpts
 		bytes.NewBuffer(data),
 	)
 	if err != nil {
-		return AuthenticationResponse{}, err
+		return EnrollAuthFactorResponse{}, err
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", "workos-go/"+workos.Version)
@@ -926,15 +926,15 @@ func (c *Client) EnrollAuthFactor(ctx context.Context, opts EnrollAuthFactorOpts
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return AuthenticationResponse{}, err
+		return EnrollAuthFactorResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos_errors.TryGetHTTPError(res); err != nil {
-		return AuthenticationResponse{}, err
+		return EnrollAuthFactorResponse{}, err
 	}
 
-	var body AuthenticationResponse
+	var body EnrollAuthFactorResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -492,7 +492,7 @@ func TestAuthenticateUserWithPassword(t *testing.T) {
 		err:      true,
 	},
 		{
-			scenario: "Request returns an AuthenticationResponse",
+			scenario: "Request returns a User",
 			client:   NewClient("test"),
 			options: AuthenticateWithPasswordOpts{
 				ClientID: "project_123",
@@ -542,7 +542,7 @@ func TestAuthenticateUserWithCode(t *testing.T) {
 		err:      true,
 	},
 		{
-			scenario: "Request returns an AuthenticationResponse",
+			scenario: "Request returns a User",
 			client:   NewClient("test"),
 			options: AuthenticateWithCodeOpts{
 				ClientID: "project_123",
@@ -591,7 +591,7 @@ func TestAuthenticateUserWithMagicAuth(t *testing.T) {
 		err:      true,
 	},
 		{
-			scenario: "Request returns an AuthenticationResponse",
+			scenario: "Request returns a User",
 			client:   NewClient("test"),
 			options: AuthenticateWithMagicAuthOpts{
 				ClientID: "project_123",
@@ -641,7 +641,7 @@ func TestAuthenticateUserWithTOTP(t *testing.T) {
 		err:      true,
 	},
 		{
-			scenario: "Request returns an AuthenticationResponse",
+			scenario: "Request returns a User",
 			client:   NewClient("test"),
 			options: AuthenticateWithTOTPOpts{
 				ClientID:                   "project_123",
@@ -1133,7 +1133,7 @@ func TestEnrollAuthFactor(t *testing.T) {
 		scenario string
 		client   *Client
 		options  EnrollAuthFactorOpts
-		expected AuthenticationResponse
+		expected EnrollAuthFactorResponse
 		err      bool
 	}{
 		{
@@ -1148,7 +1148,7 @@ func TestEnrollAuthFactor(t *testing.T) {
 				User: "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
 				Type: mfa.TOTP,
 			},
-			expected: AuthenticationResponse{
+			expected: EnrollAuthFactorResponse{
 				Factor: mfa.Factor{
 					ID:        "auth_factor_test123",
 					CreatedAt: "2022-02-17T22:39:26.616Z",
@@ -1197,7 +1197,7 @@ func enrollAuthFactorTestHandler(w http.ResponseWriter, r *http.Request) {
 	var err error
 
 	if r.URL.Path == "/user_management/users/user_01E3JC5F5Z1YJNPGVYWV9SX6GH/auth_factors" {
-		body, err = json.Marshal(AuthenticationResponse{
+		body, err = json.Marshal(EnrollAuthFactorResponse{
 			Factor: mfa.Factor{
 				ID:        "auth_factor_test123",
 				CreatedAt: "2022-02-17T22:39:26.616Z",

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -157,7 +157,7 @@ func SendMagicAuthCode(
 func EnrollAuthFactor(
 	ctx context.Context,
 	opts EnrollAuthFactorOpts,
-) (AuthenticationResponse, error) {
+) (EnrollAuthFactorResponse, error) {
 	return DefaultClient.EnrollAuthFactor(ctx, opts)
 }
 

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -394,7 +394,7 @@ func TestUserManagementEnrollAuthFactor(t *testing.T) {
 
 	SetAPIKey("test")
 
-	expectedResponse := AuthenticationResponse{
+	expectedResponse := EnrollAuthFactorResponse{
 		Factor: mfa.Factor{
 			ID:        "auth_factor_test123",
 			CreatedAt: "2022-02-17T22:39:26.616Z",


### PR DESCRIPTION
## Description
Not sure where the old name came from...

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
