### PR TITLE
Add organization_id to authenticate responses

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -176,6 +176,11 @@ type AuthenticateWithTOTPOpts struct {
 	AuthenticationChallengeID  string `json:"authentication_challenge_id"`
 }
 
+type AuthenticateResponse struct {
+	User           User   `json:"user"`
+	OrganizationID string `json:"organization_id"`
+}
+
 type SendVerificationEmailOpts struct {
 	// The unique ID of the User who will be sent a verification email.
 	User string
@@ -493,7 +498,7 @@ func (c *Client) DeleteUser(ctx context.Context, opts DeleteUserOpts) error {
 }
 
 // AuthenticateWithPassword authenticates a user with Email and Password
-func (c *Client) AuthenticateWithPassword(ctx context.Context, opts AuthenticateWithPasswordOpts) (UserResponse, error) {
+func (c *Client) AuthenticateWithPassword(ctx context.Context, opts AuthenticateWithPasswordOpts) (AuthenticateResponse, error) {
 	payload := struct {
 		AuthenticateWithPasswordOpts
 		ClientSecret string `json:"client_secret"`
@@ -506,7 +511,7 @@ func (c *Client) AuthenticateWithPassword(ctx context.Context, opts Authenticate
 
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	req, err := http.NewRequest(
@@ -516,7 +521,7 @@ func (c *Client) AuthenticateWithPassword(ctx context.Context, opts Authenticate
 	)
 
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	// Add headers and context to the request
@@ -527,16 +532,16 @@ func (c *Client) AuthenticateWithPassword(ctx context.Context, opts Authenticate
 	// Execute the request
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos_errors.TryGetHTTPError(res); err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	// Parse the JSON response
-	var body UserResponse
+	var body AuthenticateResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 
@@ -544,7 +549,7 @@ func (c *Client) AuthenticateWithPassword(ctx context.Context, opts Authenticate
 }
 
 // AuthenticateWithCode authenticates an OAuth user or a managed SSO user that is logging in through SSO
-func (c *Client) AuthenticateWithCode(ctx context.Context, opts AuthenticateWithCodeOpts) (UserResponse, error) {
+func (c *Client) AuthenticateWithCode(ctx context.Context, opts AuthenticateWithCodeOpts) (AuthenticateResponse, error) {
 	payload := struct {
 		AuthenticateWithCodeOpts
 		ClientSecret string `json:"client_secret"`
@@ -557,7 +562,7 @@ func (c *Client) AuthenticateWithCode(ctx context.Context, opts AuthenticateWith
 
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	req, err := http.NewRequest(
@@ -567,7 +572,7 @@ func (c *Client) AuthenticateWithCode(ctx context.Context, opts AuthenticateWith
 	)
 
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	// Add headers and context to the request
@@ -578,16 +583,16 @@ func (c *Client) AuthenticateWithCode(ctx context.Context, opts AuthenticateWith
 	// Execute the request
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos_errors.TryGetHTTPError(res); err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	// Parse the JSON response
-	var body UserResponse
+	var body AuthenticateResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 
@@ -596,7 +601,7 @@ func (c *Client) AuthenticateWithCode(ctx context.Context, opts AuthenticateWith
 
 // AuthenticateWithMagicAuth authenticates a user by verifying a one-time code sent to the user's email address by
 // the Magic Auth Send Code endpoint.
-func (c *Client) AuthenticateWithMagicAuth(ctx context.Context, opts AuthenticateWithMagicAuthOpts) (UserResponse, error) {
+func (c *Client) AuthenticateWithMagicAuth(ctx context.Context, opts AuthenticateWithMagicAuthOpts) (AuthenticateResponse, error) {
 	payload := struct {
 		AuthenticateWithMagicAuthOpts
 		ClientSecret string `json:"client_secret"`
@@ -609,7 +614,7 @@ func (c *Client) AuthenticateWithMagicAuth(ctx context.Context, opts Authenticat
 
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	req, err := http.NewRequest(
@@ -619,7 +624,7 @@ func (c *Client) AuthenticateWithMagicAuth(ctx context.Context, opts Authenticat
 	)
 
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	// Add headers and context to the request
@@ -630,16 +635,16 @@ func (c *Client) AuthenticateWithMagicAuth(ctx context.Context, opts Authenticat
 	// Execute the request
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos_errors.TryGetHTTPError(res); err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	// Parse the JSON response
-	var body UserResponse
+	var body AuthenticateResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 
@@ -647,7 +652,7 @@ func (c *Client) AuthenticateWithMagicAuth(ctx context.Context, opts Authenticat
 }
 
 // AuthenticateWithTOTP authenticates a user by verifying a time-based one-time password (TOTP)
-func (c *Client) AuthenticateWithTOTP(ctx context.Context, opts AuthenticateWithTOTPOpts) (UserResponse, error) {
+func (c *Client) AuthenticateWithTOTP(ctx context.Context, opts AuthenticateWithTOTPOpts) (AuthenticateResponse, error) {
 	payload := struct {
 		AuthenticateWithTOTPOpts
 		ClientSecret string `json:"client_secret"`
@@ -660,7 +665,7 @@ func (c *Client) AuthenticateWithTOTP(ctx context.Context, opts AuthenticateWith
 
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	req, err := http.NewRequest(
@@ -670,7 +675,7 @@ func (c *Client) AuthenticateWithTOTP(ctx context.Context, opts AuthenticateWith
 	)
 
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	// Add headers and context to the request
@@ -681,16 +686,16 @@ func (c *Client) AuthenticateWithTOTP(ctx context.Context, opts AuthenticateWith
 	// Execute the request
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 	defer res.Body.Close()
 
 	if err = workos_errors.TryGetHTTPError(res); err != nil {
-		return UserResponse{}, err
+		return AuthenticateResponse{}, err
 	}
 
 	// Parse the JSON response
-	var body UserResponse
+	var body AuthenticateResponse
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&body)
 

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -177,7 +177,13 @@ type AuthenticateWithTOTPOpts struct {
 }
 
 type AuthenticateResponse struct {
-	User           User   `json:"user"`
+	User User `json:"user"`
+
+	// Which Organization the user is signing in to.
+	// If the user is a member of multiple organizations, this is the organization the user selected
+	// as part of the authentication flow.
+	// If the user is a member of only one organization, this is that organization.
+	// If the user is not a member of any organizations, this is null.
 	OrganizationID string `json:"organization_id"`
 }
 

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -484,7 +484,7 @@ func TestAuthenticateUserWithPassword(t *testing.T) {
 		scenario string
 		client   *Client
 		options  AuthenticateWithPasswordOpts
-		expected UserResponse
+		expected AuthenticateResponse
 		err      bool
 	}{{
 		scenario: "Request without API Key returns an error",
@@ -499,13 +499,14 @@ func TestAuthenticateUserWithPassword(t *testing.T) {
 				Email:    "employee@foo-corp.com",
 				Password: "test_123",
 			},
-			expected: UserResponse{
+			expected: AuthenticateResponse{
 				User: User{
 					ID:        "testUserID",
 					FirstName: "John",
 					LastName:  "Doe",
 					Email:     "employee@foo-corp.com",
 				},
+				OrganizationID: "org_123",
 			},
 		},
 	}
@@ -534,7 +535,7 @@ func TestAuthenticateUserWithCode(t *testing.T) {
 		scenario string
 		client   *Client
 		options  AuthenticateWithCodeOpts
-		expected UserResponse
+		expected AuthenticateResponse
 		err      bool
 	}{{
 		scenario: "Request without API Key returns an error",
@@ -548,13 +549,14 @@ func TestAuthenticateUserWithCode(t *testing.T) {
 				ClientID: "project_123",
 				Code:     "test_123",
 			},
-			expected: UserResponse{
+			expected: AuthenticateResponse{
 				User: User{
 					ID:        "testUserID",
 					FirstName: "John",
 					LastName:  "Doe",
 					Email:     "employee@foo-corp.com",
 				},
+				OrganizationID: "org_123",
 			},
 		},
 	}
@@ -583,7 +585,7 @@ func TestAuthenticateUserWithMagicAuth(t *testing.T) {
 		scenario string
 		client   *Client
 		options  AuthenticateWithMagicAuthOpts
-		expected UserResponse
+		expected AuthenticateResponse
 		err      bool
 	}{{
 		scenario: "Request without API Key returns an error",
@@ -598,13 +600,14 @@ func TestAuthenticateUserWithMagicAuth(t *testing.T) {
 				Code:     "test_123",
 				User:     "user_123",
 			},
-			expected: UserResponse{
+			expected: AuthenticateResponse{
 				User: User{
 					ID:        "testUserID",
 					FirstName: "John",
 					LastName:  "Doe",
 					Email:     "employee@foo-corp.com",
 				},
+				OrganizationID: "org_123",
 			},
 		},
 	}
@@ -633,7 +636,7 @@ func TestAuthenticateUserWithTOTP(t *testing.T) {
 		scenario string
 		client   *Client
 		options  AuthenticateWithTOTPOpts
-		expected UserResponse
+		expected AuthenticateResponse
 		err      bool
 	}{{
 		scenario: "Request without API Key returns an error",
@@ -649,13 +652,14 @@ func TestAuthenticateUserWithTOTP(t *testing.T) {
 				PendingAuthenticationToken: "cTDQJTTkTkkVYxQUlKBIxEsFs",
 				AuthenticationChallengeID:  "auth_challenge_01H96FETXGTW1QMBSBT2T36PW0",
 			},
-			expected: UserResponse{
+			expected: AuthenticateResponse{
 				User: User{
 					ID:        "testUserID",
 					FirstName: "John",
 					LastName:  "Doe",
 					Email:     "employee@foo-corp.com",
 				},
+				OrganizationID: "org_123",
 			},
 		},
 	}
@@ -687,13 +691,14 @@ func authenticationResponseTestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if secret, exists := payload["client_secret"].(string); exists && secret != "" {
-		response := UserResponse{
+		response := AuthenticateResponse{
 			User: User{
 				ID:        "testUserID",
 				FirstName: "John",
 				LastName:  "Doe",
 				Email:     "employee@foo-corp.com",
 			},
+			OrganizationID: "org_123",
 		}
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(response)

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -83,7 +83,7 @@ func DeleteUser(
 func AuthenticateWithPassword(
 	ctx context.Context,
 	opts AuthenticateWithPasswordOpts,
-) (UserResponse, error) {
+) (AuthenticateResponse, error) {
 	return DefaultClient.AuthenticateWithPassword(ctx, opts)
 }
 
@@ -92,7 +92,7 @@ func AuthenticateWithPassword(
 func AuthenticateWithCode(
 	ctx context.Context,
 	opts AuthenticateWithCodeOpts,
-) (UserResponse, error) {
+) (AuthenticateResponse, error) {
 	return DefaultClient.AuthenticateWithCode(ctx, opts)
 }
 
@@ -101,7 +101,7 @@ func AuthenticateWithCode(
 func AuthenticateWithMagicAuth(
 	ctx context.Context,
 	opts AuthenticateWithMagicAuthOpts,
-) (UserResponse, error) {
+) (AuthenticateResponse, error) {
 	return DefaultClient.AuthenticateWithMagicAuth(ctx, opts)
 }
 
@@ -109,7 +109,7 @@ func AuthenticateWithMagicAuth(
 func AuthenticateWithTOTP(
 	ctx context.Context,
 	opts AuthenticateWithTOTPOpts,
-) (UserResponse, error) {
+) (AuthenticateResponse, error) {
 	return DefaultClient.AuthenticateWithTOTP(ctx, opts)
 }
 

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -304,13 +304,14 @@ func TestUserManagementAuthenticateWithCode(t *testing.T) {
 
 	SetAPIKey("test")
 
-	expectedResponse := UserResponse{
+	expectedResponse := AuthenticateResponse{
 		User: User{
 			ID:        "testUserID",
 			FirstName: "John",
 			LastName:  "Doe",
 			Email:     "employee@foo-corp.com",
 		},
+		OrganizationID: "org_123",
 	}
 
 	authenticationRes, err := AuthenticateWithCode(context.Background(), AuthenticateWithCodeOpts{})
@@ -328,13 +329,14 @@ func TestUserManagementAuthenticateWithPassword(t *testing.T) {
 
 	SetAPIKey("test")
 
-	expectedResponse := UserResponse{
+	expectedResponse := AuthenticateResponse{
 		User: User{
 			ID:        "testUserID",
 			FirstName: "John",
 			LastName:  "Doe",
 			Email:     "employee@foo-corp.com",
 		},
+		OrganizationID: "org_123",
 	}
 
 	authenticationRes, err := AuthenticateWithPassword(context.Background(), AuthenticateWithPasswordOpts{})
@@ -352,13 +354,14 @@ func TestUserManagementAuthenticateWithMagicAuth(t *testing.T) {
 
 	SetAPIKey("test")
 
-	expectedResponse := UserResponse{
+	expectedResponse := AuthenticateResponse{
 		User: User{
 			ID:        "testUserID",
 			FirstName: "John",
 			LastName:  "Doe",
 			Email:     "employee@foo-corp.com",
 		},
+		OrganizationID: "org_123",
 	}
 
 	authenticationRes, err := AuthenticateWithMagicAuth(context.Background(), AuthenticateWithMagicAuthOpts{})
@@ -376,13 +379,14 @@ func TestUserManagementAuthenticateWithTOTP(t *testing.T) {
 
 	SetAPIKey("test")
 
-	expectedResponse := UserResponse{
+	expectedResponse := AuthenticateResponse{
 		User: User{
 			ID:        "testUserID",
 			FirstName: "John",
 			LastName:  "Doe",
 			Email:     "employee@foo-corp.com",
 		},
+		OrganizationID: "org_123",
 	}
 
 	authenticationRes, err := AuthenticateWithTOTP(context.Background(), AuthenticateWithTOTPOpts{})


### PR DESCRIPTION
## Description
Adds `organization_id` to authenticate responses

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
