### PR TITLE
Make GetOrganizationMembership consistent with other Get* functions

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -269,7 +269,7 @@ type ListAuthFactorsResponse struct {
 
 type GetOrganizationMembershipOpts struct {
 	// Organization Membership unique identifier
-	OrganizationMembershipID string
+	OrganizationMembership string
 }
 
 type ListOrganizationMembershipsOpts struct {
@@ -310,7 +310,7 @@ type CreateOrganizationMembershipOpts struct {
 
 type DeleteOrganizationMembershipOpts struct {
 	// The ID of the Organization Membership to delete.
-	OrganizationMembershipID string
+	OrganizationMembership string
 }
 
 func NewClient(apiKey string) *Client {
@@ -1124,7 +1124,7 @@ func (c *Client) GetOrganizationMembership(ctx context.Context, opts GetOrganiza
 	endpoint := fmt.Sprintf(
 		"%s/user_management/organization_memberships/%s",
 		c.Endpoint,
-		opts.OrganizationMembershipID,
+		opts.OrganizationMembership,
 	)
 
 	req, err := http.NewRequest(
@@ -1252,7 +1252,7 @@ func (c *Client) DeleteOrganizationMembership(ctx context.Context, opts DeleteOr
 	endpoint := fmt.Sprintf(
 		"%s/user_management/organization_memberships/%s",
 		c.Endpoint,
-		opts.OrganizationMembershipID,
+		opts.OrganizationMembership,
 	)
 
 	req, err := http.NewRequest(

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -1444,7 +1444,7 @@ func TestGetOrganizationMembership(t *testing.T) {
 			scenario: "Request returns an Organization Membership",
 			client:   NewClient("test"),
 			options: GetOrganizationMembershipOpts{
-				OrganizationMembershipID: "om_01E4ZCR3C56J083X43JQXF3JK5",
+				OrganizationMembership: "om_01E4ZCR3C56J083X43JQXF3JK5",
 			},
 			expected: OrganizationMembership{
 				ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
@@ -1713,7 +1713,7 @@ func TestDeleteOrganizationMembership(t *testing.T) {
 			scenario: "Request returns OrganizationMembership",
 			client:   NewClient("test"),
 			options: DeleteOrganizationMembershipOpts{
-				OrganizationMembershipID: "om_01E4ZCR3C56J083X43JQXF3JK5",
+				OrganizationMembership: "om_01E4ZCR3C56J083X43JQXF3JK5",
 			},
 			expected: nil,
 		},

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -556,7 +556,7 @@ func TestUserManagementGetOrganizationMembership(t *testing.T) {
 	}
 
 	userRes, err := GetOrganizationMembership(context.Background(), GetOrganizationMembershipOpts{
-		OrganizationMembershipID: "om_01E4ZCR3C56J083X43JQXF3JK5",
+		OrganizationMembership: "om_01E4ZCR3C56J083X43JQXF3JK5",
 	})
 
 	require.NoError(t, err)
@@ -627,7 +627,7 @@ func TestUsersDeleteOrganizationMembership(t *testing.T) {
 	SetAPIKey("test")
 
 	err := DeleteOrganizationMembership(context.Background(), DeleteOrganizationMembershipOpts{
-		OrganizationMembershipID: "om_01E4ZCR3C56J083X43JQXF3JK5",
+		OrganizationMembership: "om_01E4ZCR3C56J083X43JQXF3JK5",
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Description
We don't use `*ID` elsewhere.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
