### PR TITLE
Remove "suspended" state from Directory Sync user object

### DIFF
--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -81,8 +81,8 @@ type UserState string
 
 // Constants that enumerate the state of a Directory User.
 const (
-	Active    UserState = "active"
-	Inactive  UserState = "inactive"
+	Active   UserState = "active"
+	Inactive UserState = "inactive"
 )
 
 // User contains data about a provisioned Directory User.

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -83,7 +83,6 @@ type UserState string
 const (
 	Active    UserState = "active"
 	Inactive  UserState = "inactive"
-	Suspended UserState = "suspended"
 )
 
 // User contains data about a provisioned Directory User.


### PR DESCRIPTION
## Description
"suspended" state is now deprecated and consolidated into the "inactive" state

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
