### PR TITLE
Remove "domain" param from directories query

### DIFF
--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -484,9 +484,6 @@ type Directory struct {
 
 // ListDirectoriesOpts contains the options to request a Project's Directories.
 type ListDirectoriesOpts struct {
-	// Domain of a Directory. Can be empty.
-	Domain string `url:"domain,omitempty"`
-
 	// Searchable text for a Directory. Can be empty.
 	Search string `url:"search,omitempty"`
 


### PR DESCRIPTION
## Description
We no longer support querying directories by domain.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
