### PR TITLE
Add `ProfilePictureURL` to `User` struct

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -103,6 +103,9 @@ type User struct {
 
 	// Whether the User email is verified.
 	EmailVerified bool `json:"email_verified"`
+
+	// A URL reference to an image representing the User.
+	ProfilePictureURL string `json:"profile_picture_url"`
 }
 
 // GetUserOpts contains the options to pass in order to get a user profile.

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -43,6 +43,23 @@ func TestGetUser(t *testing.T) {
 				UpdatedAt:     "2021-06-25T19:07:33.155Z",
 			},
 		},
+		{
+			scenario: "Request returns a User with an unmarshalled `ProfilePictureURL`",
+			client:   NewClient("test"),
+			options: GetUserOpts{
+				User: "user_456",
+			},
+			expected: User{
+				ID:                "user_01E3JC5F5Z1YJNPGVYWV9SX456",
+				Email:             "marcelina@foo-corp.com",
+				FirstName:         "Marcelina",
+				LastName:          "Davis",
+				EmailVerified:     true,
+				ProfilePictureURL: "https://workoscdn.com/images/v1/123abc",
+				CreatedAt:         "2021-06-25T19:07:33.155Z",
+				UpdatedAt:         "2021-06-25T19:07:33.155Z",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -84,6 +101,19 @@ func getUserTestHandler(w http.ResponseWriter, r *http.Request) {
 			EmailVerified: true,
 			CreatedAt:     "2021-06-25T19:07:33.155Z",
 			UpdatedAt:     "2021-06-25T19:07:33.155Z",
+		})
+	}
+
+	if r.URL.Path == "/user_management/users/user_456" {
+		body, err = json.Marshal(User{
+			ID:                "user_01E3JC5F5Z1YJNPGVYWV9SX456",
+			Email:             "marcelina@foo-corp.com",
+			FirstName:         "Marcelina",
+			LastName:          "Davis",
+			EmailVerified:     true,
+			ProfilePictureURL: "https://workoscdn.com/images/v1/123abc",
+			CreatedAt:         "2021-06-25T19:07:33.155Z",
+			UpdatedAt:         "2021-06-25T19:07:33.155Z",
 		})
 	}
 


### PR DESCRIPTION
## Description

Adds a new `ProfilePictureURL` field to the `User` struct.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
