### PR TITLE
chore: default list methods to descending order

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: workos-go pipeline
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 blocks:
   - name: Check code style

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WorkOS Go Library
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/workos/workos-go/v3.svg)](https://pkg.go.dev/github.com/workos/workos-go/v3)
+[![Go Reference](https://pkg.go.dev/badge/github.com/workos/workos-go/v4.svg)](https://pkg.go.dev/github.com/workos/workos-go/v4)
 
 The WorkOS library for Go provides convenient access to the WorkOS API from applications written in Go.
 
@@ -13,7 +13,7 @@ See the [API Reference](https://workos.com/docs/reference/client-libraries) for 
 Install the package with:
 
 ```
-go get -u github.com/workos/workos-go/v3...
+go get -u github.com/workos/workos-go/v4...
 ```
 
 ## Configuration
@@ -30,10 +30,10 @@ Or, you can set it on your own before your application starts:
 sso.Configure(
   "<WORKOS_API_KEY>",
   "<CLIENT_ID>",
-  "https://foo-corp.com/redirect-uri",
-)
+  "https://foo-corp.com/redirect-uri"
+);
 
-directorysync.SetAPIKey("<WORKOS_API_KEY>")
+directorysync.SetAPIKey("<WORKOS_API_KEY>");
 ```
 
 ## SDK Versioning

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
-module github.com/workos/workos-go/v3
+module github.com/workos/workos-go/v4
 
 go 1.13
 
 require (
 	github.com/google/go-querystring v1.0.0
-	github.com/google/uuid v1.1.1
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
-github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v3.2.0"
+	Version = "v4.0.0"
 )

--- a/pkg/auditlogs/README.md
+++ b/pkg/auditlogs/README.md
@@ -1,13 +1,13 @@
 # auditlogs
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v3/pkg/auditlogs)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/auditlogs)
 
 A Go package to send audit log events to WorkOS.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v3/pkg/auditlogs
+go get -u github.com/workos/workos-go/v4/pkg/auditlogs
 ```
 
 ## How it works
@@ -15,7 +15,7 @@ go get -u github.com/workos/workos-go/v3/pkg/auditlogs
 ```go
 package main
 
-import "github.com/workos/workos-go/v3/pkg/auditlogs"
+import "github.com/workos/workos-go/v4/pkg/auditlogs"
 
 func main() {
 	auditlogs.SetAPIKey("my_api_key")

--- a/pkg/auditlogs/client.go
+++ b/pkg/auditlogs/client.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v3/internal/workos"
+	"github.com/workos/workos-go/v4/internal/workos"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/auditlogs/client_test.go
+++ b/pkg/auditlogs/client_test.go
@@ -3,7 +3,7 @@ package auditlogs
 import (
 	"context"
 	"encoding/json"
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"

--- a/pkg/directorysync/README.md
+++ b/pkg/directorysync/README.md
@@ -1,13 +1,13 @@
 # directorysync
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v3/pkg/directorysync)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/directorysync)
 
 A Go package to make requests to the WorkOS Directory Sync API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v3/pkg/directorysync
+go get -u github.com/workos/workos-go/v4/pkg/directorysync
 ```
 
 ## How it works

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v3/internal/workos"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/internal/workos"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -189,6 +189,10 @@ func (c *Client) ListUsers(
 		opts.Limit = ResponseLimit
 	}
 
+	if opts.Order == "" {
+        opts.Order = Desc
+    }
+
 	v, err := query.Values(opts)
 	if err != nil {
 		return ListUsersResponse{}, err
@@ -294,6 +298,10 @@ func (c *Client) ListGroups(
 	if opts.Limit == 0 {
 		opts.Limit = ResponseLimit
 	}
+
+	if opts.Order == "" {
+        opts.Order = Desc
+    }
 
 	v, err := query.Values(opts)
 	if err != nil {
@@ -540,6 +548,10 @@ func (c *Client) ListDirectories(
 	if opts.Limit == 0 {
 		opts.Limit = ResponseLimit
 	}
+
+	if opts.Order == "" {
+        opts.Order = Desc
+    }
 
 	v, err := query.Values(opts)
 	if err != nil {

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -190,8 +190,8 @@ func (c *Client) ListUsers(
 	}
 
 	if opts.Order == "" {
-        opts.Order = Desc
-    }
+		opts.Order = Desc
+	}
 
 	v, err := query.Values(opts)
 	if err != nil {
@@ -300,8 +300,8 @@ func (c *Client) ListGroups(
 	}
 
 	if opts.Order == "" {
-        opts.Order = Desc
-    }
+		opts.Order = Desc
+	}
 
 	v, err := query.Values(opts)
 	if err != nil {
@@ -550,8 +550,8 @@ func (c *Client) ListDirectories(
 	}
 
 	if opts.Order == "" {
-        opts.Order = Desc
-    }
+		opts.Order = Desc
+	}
 
 	v, err := query.Values(opts)
 	if err != nil {

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 func TestListUsers(t *testing.T) {

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 func TestDirectorySyncListUsers(t *testing.T) {

--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -5,7 +5,7 @@ A Go package to retrieve events from WorkOS.
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v3/pkg/events
+go get -u github.com/workos/workos-go/v4/pkg/events
 ```
 
 ## How it works
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/workos/workos-go/v3/pkg/events"
+	"github.com/workos/workos-go/v4/pkg/events"
 )
 
 func main() {

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v3/internal/workos"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/internal/workos"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 func TestListEvents(t *testing.T) {

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 func TestEventsListEvents(t *testing.T) {

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v3/internal/workos"
+	"github.com/workos/workos-go/v4/internal/workos"
 )
 
 // This represents the list of errors that could be raised when using the mfa package

--- a/pkg/organizations/README.md
+++ b/pkg/organizations/README.md
@@ -1,13 +1,13 @@
 # organizations
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v3/pkg/organizations)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/organizations)
 
 A Go package to make requests to the WorkOS Organizations API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v3/pkg/organizations
+go get -u github.com/workos/workos-go/v4/pkg/organizations
 ```
 
 ## How it works

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -9,11 +9,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v3/internal/workos"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/internal/workos"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -225,6 +225,10 @@ func (c *Client) ListOrganizations(
 		opts.Limit = ResponseLimit
 	}
 
+	if opts.Order == "" {
+        opts.Order = Desc
+    }
+
 	q, err := query.Values(opts)
 	if err != nil {
 		return ListOrganizationsResponse{}, err

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -226,8 +226,8 @@ func (c *Client) ListOrganizations(
 	}
 
 	if opts.Order == "" {
-        opts.Order = Desc
-    }
+		opts.Order = Desc
+	}
 
 	q, err := query.Values(opts)
 	if err != nil {

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 func TestGetOrganization(t *testing.T) {

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 func TestOrganizationsGetOrganization(t *testing.T) {

--- a/pkg/passwordless/README.md
+++ b/pkg/passwordless/README.md
@@ -1,13 +1,13 @@
 # passwordless
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v3/pkg/passwordless)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/passwordless)
 
 A Go package to make requests to the WorkOS Magic Link API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v3/pkg/passwordless
+go get -u github.com/workos/workos-go/v4/pkg/passwordless
 ```
 
 ## How it works

--- a/pkg/passwordless/client.go
+++ b/pkg/passwordless/client.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v3/internal/workos"
+	"github.com/workos/workos-go/v4/internal/workos"
 )
 
 // Client represents a client that performs Passwordless requests to the WorkOS API.

--- a/pkg/portal/README.md
+++ b/pkg/portal/README.md
@@ -1,13 +1,13 @@
 # portal
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v3/pkg/portal)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/portal)
 
 A Go package to make requests to the WorkOS Admin Portal API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v3/pkg/portal
+go get -u github.com/workos/workos-go/v4/pkg/portal
 ```
 
 ## How it works

--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v3/internal/workos"
+	"github.com/workos/workos-go/v4/internal/workos"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/sso/README.md
+++ b/pkg/sso/README.md
@@ -1,13 +1,13 @@
 # sso
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v3/pkg/sso)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/sso)
 
 A go package to request WorkOS SSO API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v3/pkg/sso
+go get -u github.com/workos/workos-go/v4/pkg/sso
 ```
 
 ## How it works

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -512,6 +512,10 @@ func (c *Client) ListConnections(
 		opts.Limit = ResponseLimit
 	}
 
+	if opts.Order == "" {
+        opts.Order = Desc
+    }
+
 	v, err := query.Values(opts)
 	if err != nil {
 		return ListConnectionsResponse{}, err

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -513,8 +513,8 @@ func (c *Client) ListConnections(
 	}
 
 	if opts.Order == "" {
-        opts.Order = Desc
-    }
+		opts.Order = Desc
+	}
 
 	v, err := query.Values(opts)
 	if err != nil {

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -6,15 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v3/internal/workos"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/internal/workos"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 func TestClientAuthorizeURL(t *testing.T) {

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v3/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/common"
 )
 
 func TestLogin(t *testing.T) {

--- a/pkg/usermanagement/README.md
+++ b/pkg/usermanagement/README.md
@@ -1,13 +1,13 @@
 # usermanagement
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v3/pkg/usermanagement)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/usermanagement)
 
 A go package wrapping the WorkOS User Management API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v3/pkg/usermanagement
+go get -u github.com/workos/workos-go/v4/pkg/usermanagement
 ```
 
 ## How it works

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -455,6 +455,10 @@ func (c *Client) ListUsers(ctx context.Context, opts ListUsersOpts) (ListUsersRe
 		opts.Limit = ResponseLimit
 	}
 
+	if opts.Order == "" {
+        opts.Order = Desc
+    }
+
 	queryValues, err := query.Values(opts)
 	if err != nil {
 		return ListUsersResponse{}, err
@@ -1321,6 +1325,10 @@ func (c *Client) ListOrganizationMemberships(ctx context.Context, opts ListOrgan
 		opts.Limit = ResponseLimit
 	}
 
+	if opts.Order == "" {
+        opts.Order = Desc
+    }
+
 	queryValues, err := query.Values(opts)
 	if err != nil {
 		return ListOrganizationMembershipsResponse{}, err
@@ -1470,6 +1478,10 @@ func (c *Client) ListInvitations(ctx context.Context, opts ListInvitationsOpts) 
 	if opts.Limit == 0 {
 		opts.Limit = ResponseLimit
 	}
+
+	if opts.Order == "" {
+        opts.Order = Desc
+    }
 
 	queryValues, err := query.Values(opts)
 	if err != nil {

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v3/internal/workos"
-	"github.com/workos/workos-go/v3/pkg/common"
-	"github.com/workos/workos-go/v3/pkg/mfa"
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/internal/workos"
+	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/mfa"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -456,8 +456,8 @@ func (c *Client) ListUsers(ctx context.Context, opts ListUsersOpts) (ListUsersRe
 	}
 
 	if opts.Order == "" {
-        opts.Order = Desc
-    }
+		opts.Order = Desc
+	}
 
 	queryValues, err := query.Values(opts)
 	if err != nil {
@@ -1326,8 +1326,8 @@ func (c *Client) ListOrganizationMemberships(ctx context.Context, opts ListOrgan
 	}
 
 	if opts.Order == "" {
-        opts.Order = Desc
-    }
+		opts.Order = Desc
+	}
 
 	queryValues, err := query.Values(opts)
 	if err != nil {
@@ -1480,8 +1480,8 @@ func (c *Client) ListInvitations(ctx context.Context, opts ListInvitationsOpts) 
 	}
 
 	if opts.Order == "" {
-        opts.Order = Desc
-    }
+		opts.Order = Desc
+	}
 
 	queryValues, err := query.Values(opts)
 	if err != nil {

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v3/pkg/common"
-	"github.com/workos/workos-go/v3/pkg/mfa"
+	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/mfa"
 )
 
 func TestGetUser(t *testing.T) {

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/workos/workos-go/v3/pkg/common"
-	"github.com/workos/workos-go/v3/pkg/mfa"
+	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/mfa"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	"github.com/workos/workos-go/v3/pkg/webhooks"
+	"github.com/workos/workos-go/v4/pkg/webhooks"
 	"strconv"
 	"testing"
 	"time"

--- a/pkg/workos_errors/errors_test.go
+++ b/pkg/workos_errors/errors_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/workos/workos-go/v3/pkg/workos_errors"
+	"github.com/workos/workos-go/v4/pkg/workos_errors"
 )
 
 func TestIsBadRequest(t *testing.T) {


### PR DESCRIPTION
## Description
Default list methods to descending order.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
