### PR TITLE
Add Impersonation-related fields and event type

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -40,6 +40,7 @@ const (
 	UserCreated                   = "user.created"
 	UserUpdated                   = "user.updated"
 	UserDeleted                   = "user.deleted"
+	UserImpersonated              = "user.impersonated"
 	OrganizationMembershipAdded   = "organization_membership.added"
 	OrganizationMembershipUpdated = "organization_membership.updated"
 	OrganizationMembershipRemoved = "organization_membership.removed"

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -249,7 +249,7 @@ type Impersonator struct {
 	// The email address of the WorkOS Dashboard user using impersonation.
 	Email string `json:"email"`
 
-	// The reason provided by the impersoantor for impersonating the user.
+	// The reason provided by the impersonator for impersonating the user.
 	Reason string `json:"reason"`
 }
 

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -238,6 +238,14 @@ type AuthenticateWithOrganizationSelectionOpts struct {
 	UserAgent                  string `json:"user_agent,omitempty"`
 }
 
+type Impersonator struct {
+	// The email address of the WorkOS Dashboard user using impersonation.
+	Email string `json:"email"`
+
+	// The reason provided by the impersoantor for impersonating the user.
+	Reason string `json:"reason"`
+}
+
 type AuthenticateResponse struct {
 	User User `json:"user"`
 
@@ -247,6 +255,9 @@ type AuthenticateResponse struct {
 	// If the user is a member of only one organization, this is that organization.
 	// If the user is not a member of any organizations, this is null.
 	OrganizationID string `json:"organization_id"`
+
+	// Present if the authenticated user is being impersonated.
+	Impersonator *Impersonator `json:"impersonator"`
 }
 
 type SendVerificationEmailOpts struct {


### PR DESCRIPTION
## Description

Adds support for the impersonator metadata in authentication responses, along with a new user.impersonated event.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
