### PR TITLE
Add role to OrganizationMembership and new PUT OrganizationMembership endpoint

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.1.0"
+	Version = "v4.0.0"
 )

--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.0.0"
+	Version = "v4.1.0"
 )

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -71,6 +71,11 @@ const (
 	PendingOrganizationMembership OrganizationMembershipStatus = "pending"
 )
 
+type RoleResponse struct {
+	// The slug of the role
+	Slug string `json:"slug"`
+}
+
 // OrganizationMembership contains data about a particular OrganizationMembership.
 type OrganizationMembership struct {
 	// The Organization Membership's unique identifier.
@@ -81,6 +86,9 @@ type OrganizationMembership struct {
 
 	// The ID of the Organization.
 	OrganizationID string `json:"organization_id"`
+
+	// The role given to this Organization Membership
+	Role RoleResponse `json:"role"`
 
 	// The Status of the Organization.
 	Status OrganizationMembershipStatus `json:"status"`
@@ -347,6 +355,10 @@ type CreateOrganizationMembershipOpts struct {
 
 	// The ID of the Organization in which to add the User as a member.
 	OrganizationID string `json:"organization_id"`
+
+	// The slug of the Role in which to this membership. If not RoleSlug is given, the default role will be granted.
+	// OPTIONAL
+	RoleSlug string `json:"role_slug"`
 }
 
 type DeleteOrganizationMembershipOpts struct {

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -356,7 +356,7 @@ type CreateOrganizationMembershipOpts struct {
 	// The ID of the Organization in which to add the User as a member.
 	OrganizationID string `json:"organization_id"`
 
-	// The slug of the Role in which to this membership. If no RoleSlug is given, the default role will be granted.
+	// The slug of the Role in which to grant this membership. If no RoleSlug is given, the default role will be granted.
 	// OPTIONAL
 	RoleSlug string `json:"role_slug,omitempty"`
 }

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -1464,7 +1464,7 @@ func (c *Client) UpdateOrganizationMembership(
 	endpoint := fmt.Sprintf(
 		"%s/user_management/organization_memberships/%s",
 		c.Endpoint,
-		opts.OrganizationMembership,
+		organizationMembershipId,
 	)
 
 	data, err := c.JSONEncode(opts)

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -222,7 +222,7 @@ func UpdateOrganizationMembership(
 	organizationMembershipId string,
 	opts UpdateOrganizationMembershipOpts,
 ) (OrganizationMembership, error) {
-	return DefaultClient.UpdateOrganizationMembership(ctx, opts)
+	return DefaultClient.UpdateOrganizationMembership(ctx, organizationMembershipId, opts)
 }
 
 // DeleteOrganizationMembership deletes an existing OrganizationMembership.

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -208,7 +208,7 @@ func ListOrganizationMemberships(
 	return DefaultClient.ListOrganizationMemberships(ctx, opts)
 }
 
-// CreateOrganizationMembership creates a OrganizationMembership.
+// CreateOrganizationMembership creates an OrganizationMembership.
 func CreateOrganizationMembership(
 	ctx context.Context,
 	opts CreateOrganizationMembershipOpts,
@@ -216,7 +216,16 @@ func CreateOrganizationMembership(
 	return DefaultClient.CreateOrganizationMembership(ctx, opts)
 }
 
-// DeleteOrganizationMembership deletes a existing OrganizationMembership.
+// UpdateOrganizationMembership updates an OrganizationMembership.
+func UpdateOrganizationMembership(
+	ctx context.Context,
+	organizationMembershipId string,
+	opts UpdateOrganizationMembershipOpts,
+) (OrganizationMembership, error) {
+	return DefaultClient.UpdateOrganizationMembership(ctx, opts)
+}
+
+// DeleteOrganizationMembership deletes an existing OrganizationMembership.
 func DeleteOrganizationMembership(
 	ctx context.Context,
 	opts DeleteOrganizationMembershipOpts,

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -596,7 +596,7 @@ func TestUserManagementCreateOrganizationMembership(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedRole := RoleResponse{
-		Slug:          "member",
+		Slug: "member",
 	}
 
 	expectedResponse := OrganizationMembership{

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -595,11 +595,16 @@ func TestUserManagementCreateOrganizationMembership(t *testing.T) {
 
 	SetAPIKey("test")
 
+	expectedRole := RoleResponse{
+		Slug:						"member",
+	}
+
 	expectedResponse := OrganizationMembership{
 		ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
 		UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
 		OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
 		Status:         Active,
+		Role:						expectedRole,
 		CreatedAt:      "2021-06-25T19:07:33.155Z",
 		UpdatedAt:      "2021-06-25T19:07:33.155Z",
 	}

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -634,6 +634,26 @@ func TestUsersDeleteOrganizationMembership(t *testing.T) {
 	require.Equal(t, nil, err)
 }
 
+func TestUsersUpdateOrganizationMembership(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(updateOrganizationMembershipTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	err := UpdateOrganizationMembership(
+		context.Background(),
+		"om_01E4ZCR3C56J083X43JQXF3JK5",
+		UpdateOrganizationMembershipOpts{
+			RoleSlug: "member",
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, nil, err)
+}
+
 func TestUsersGetInvitation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(getInvitationTestHandler))
 	defer server.Close()

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -596,7 +596,7 @@ func TestUserManagementCreateOrganizationMembership(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedRole := RoleResponse{
-		Slug:						"member",
+		Slug:          "member",
 	}
 
 	expectedResponse := OrganizationMembership{
@@ -604,7 +604,7 @@ func TestUserManagementCreateOrganizationMembership(t *testing.T) {
 		UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
 		OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
 		Status:         Active,
-		Role:						expectedRole,
+		Role:           expectedRole,
 		CreatedAt:      "2021-06-25T19:07:33.155Z",
 		UpdatedAt:      "2021-06-25T19:07:33.155Z",
 	}

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -642,7 +642,21 @@ func TestUsersUpdateOrganizationMembership(t *testing.T) {
 
 	SetAPIKey("test")
 
-	err := UpdateOrganizationMembership(
+	expectedRole := RoleResponse{
+		Slug: "member",
+	}
+
+	expectedResponse := OrganizationMembership{
+		ID:             "om_01E4ZCR3C56J083X43JQXF3JK5",
+		UserID:         "user_01E4ZCR3C5A4QZ2Z2JQXGKZJ9E",
+		OrganizationID: "org_01E4ZCR3C56J083X43JQXF3JK5",
+		Status:         Active,
+		Role:           expectedRole,
+		CreatedAt:      "2021-06-25T19:07:33.155Z",
+		UpdatedAt:      "2021-06-25T19:07:33.155Z",
+	}
+
+	body, err := UpdateOrganizationMembership(
 		context.Background(),
 		"om_01E4ZCR3C56J083X43JQXF3JK5",
 		UpdateOrganizationMembershipOpts{
@@ -651,7 +665,7 @@ func TestUsersUpdateOrganizationMembership(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	require.Equal(t, nil, err)
+	require.Equal(t, expectedResponse, body)
 }
 
 func TestUsersGetInvitation(t *testing.T) {


### PR DESCRIPTION
## Description
New "role" parameter which is used in the User Management OrganizationMemberships API


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
