### PR TITLE
Add session endpoints

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -1660,3 +1660,16 @@ func (c *Client) RevokeInvitation(ctx context.Context, opts RevokeInvitationOpts
 
 	return body, err
 }
+
+func (c *Client) GetJWKSURL(clientID string) (*url.URL, error) {
+	if clientID == "" {
+		return nil, errors.New("clientID must not be blank")
+	}
+
+	u, err := url.ParseRequestURI(c.Endpoint + "/sso/jwks/" + clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	return u, nil
+}

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -1673,3 +1673,28 @@ func (c *Client) GetJWKSURL(clientID string) (*url.URL, error) {
 
 	return u, nil
 }
+
+type GetLogoutURLOpts struct {
+	// The ID of the session that will end. This is in the `sid` claim of the
+	// AccessToken
+	//
+	// REQUIRED
+	SessionID string
+}
+
+func (c *Client) GetLogoutURL(opts GetLogoutURLOpts) (*url.URL, error) {
+	if opts.SessionID == "" {
+		return nil, errors.New("incomplete arguments: missing SessionID")
+	}
+
+	u, err := url.ParseRequestURI(c.Endpoint + "/user_management/sessions/logout")
+	if err != nil {
+		return nil, err
+	}
+
+	query := make(url.Values, 1)
+	query.Set("session_id", opts.SessionID)
+	u.RawQuery = query.Encode()
+
+	return u, nil
+}

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -666,6 +666,8 @@ func TestAuthenticateUserWithPassword(t *testing.T) {
 					Email:     "employee@foo-corp.com",
 				},
 				OrganizationID: "org_123",
+				AccessToken:    "access_token",
+				RefreshToken:   "refresh_token",
 			},
 		},
 	}
@@ -716,6 +718,8 @@ func TestAuthenticateUserWithCode(t *testing.T) {
 					Email:     "employee@foo-corp.com",
 				},
 				OrganizationID: "org_123",
+				AccessToken:    "access_token",
+				RefreshToken:   "refresh_token",
 			},
 		},
 	}
@@ -729,6 +733,51 @@ func TestAuthenticateUserWithCode(t *testing.T) {
 			client.HTTPClient = server.Client()
 
 			response, err := client.AuthenticateWithCode(context.Background(), test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, response)
+		})
+	}
+}
+
+func TestAuthenticateUserWithRefreshToken(t *testing.T) {
+	tests := []struct {
+		scenario string
+		client   *Client
+		options  AuthenticateWithRefreshTokenOpts
+		expected RefreshAuthenticationResponse
+		err      bool
+	}{{
+		scenario: "Request without API Key returns an error",
+		client:   NewClient(""),
+		err:      true,
+	},
+		{
+			scenario: "Request new tokens",
+			client:   NewClient("test"),
+			options: AuthenticateWithRefreshTokenOpts{
+				ClientID:     "project_123",
+				RefreshToken: "refresh_token",
+			},
+			expected: RefreshAuthenticationResponse{
+				AccessToken:  "access_token",
+				RefreshToken: "new_refresh_token",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(refreshAuthenticationResponseTestHandler))
+			defer server.Close()
+
+			client := test.client
+			client.Endpoint = server.URL
+			client.HTTPClient = server.Client()
+
+			response, err := client.AuthenticateWithRefreshToken(context.Background(), test.options)
 			if test.err {
 				require.Error(t, err)
 				return
@@ -768,6 +817,8 @@ func TestAuthenticateUserWithMagicAuth(t *testing.T) {
 					Email:     "employee@foo-corp.com",
 				},
 				OrganizationID: "org_123",
+				AccessToken:    "access_token",
+				RefreshToken:   "refresh_token",
 			},
 		},
 	}
@@ -820,6 +871,8 @@ func TestAuthenticateUserWithTOTP(t *testing.T) {
 					Email:     "employee@foo-corp.com",
 				},
 				OrganizationID: "org_123",
+				AccessToken:    "access_token",
+				RefreshToken:   "refresh_token",
 			},
 		},
 	}
@@ -871,6 +924,8 @@ func TestAuthenticateUserWithEmailVerificationCode(t *testing.T) {
 					Email:     "employee@foo-corp.com",
 				},
 				OrganizationID: "org_123",
+				AccessToken:    "access_token",
+				RefreshToken:   "refresh_token",
 			},
 		},
 	}
@@ -922,6 +977,8 @@ func TestAuthenticateUserWithOrganizationSelection(t *testing.T) {
 					Email:     "employee@foo-corp.com",
 				},
 				OrganizationID: "org_123",
+				AccessToken:    "access_token",
+				RefreshToken:   "refresh_token",
 			},
 		},
 	}
@@ -961,6 +1018,28 @@ func authenticationResponseTestHandler(w http.ResponseWriter, r *http.Request) {
 				Email:     "employee@foo-corp.com",
 			},
 			OrganizationID: "org_123",
+			AccessToken:    "access_token",
+			RefreshToken:   "refresh_token",
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	w.WriteHeader(http.StatusUnauthorized)
+}
+
+func refreshAuthenticationResponseTestHandler(w http.ResponseWriter, r *http.Request) {
+
+	payload := make(map[string]interface{})
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if secret, exists := payload["client_secret"].(string); exists && secret != "" {
+		response := AuthenticateResponse{
+			AccessToken:  "access_token",
+			RefreshToken: "new_refresh_token",
 		}
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(response)

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -2283,3 +2283,16 @@ func RevokeInvitationTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(body)
 }
+
+func RevokeSessionTestHandler(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	if auth != "Bearer test" {
+		http.Error(w, "bad auth", http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -267,3 +267,7 @@ func GetJWKSURL(clientID string) (*url.URL, error) {
 func GetLogoutURL(opts GetLogoutURLOpts) (*url.URL, error) {
 	return DefaultClient.GetLogoutURL(opts)
 }
+
+func RevokeSession(ctx context.Context, opts RevokeSessionOpts) error {
+	return DefaultClient.RevokeSession(ctx, opts)
+}

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -86,7 +86,7 @@ func GetAuthorizationURL(opts GetAuthorizationURLOpts) (*url.URL, error) {
 	return DefaultClient.GetAuthorizationURL(opts)
 }
 
-// AuthenticateWithPassword authenticates a user with email and password and optionally creates a session.
+// AuthenticateWithPassword authenticates a user with email and password
 func AuthenticateWithPassword(
 	ctx context.Context,
 	opts AuthenticateWithPasswordOpts,
@@ -94,13 +94,21 @@ func AuthenticateWithPassword(
 	return DefaultClient.AuthenticateWithPassword(ctx, opts)
 }
 
-// AuthenticateWithCode authenticates an OAuth user or a managed SSO user that is logging in through SSO, and
-// optionally creates a session.
+// AuthenticateWithCode authenticates an OAuth user or a managed SSO user that is logging in through SSO
 func AuthenticateWithCode(
 	ctx context.Context,
 	opts AuthenticateWithCodeOpts,
 ) (AuthenticateResponse, error) {
 	return DefaultClient.AuthenticateWithCode(ctx, opts)
+}
+
+// AuthenticateWithRefreshToken obtains a new AccessToken and RefreshToken for
+// an existing session
+func AuthenticateWithRefreshToken(
+	ctx context.Context,
+	opts AuthenticateWithRefreshTokenOpts,
+) (RefreshAuthenticationResponse, error) {
+	return DefaultClient.AuthenticateWithRefreshToken(ctx, opts)
 }
 
 // AuthenticateWithMagicAuth authenticates a user by verifying a one-time code sent to the user's email address by

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -263,3 +263,7 @@ func RevokeInvitation(
 func GetJWKSURL(clientID string) (*url.URL, error) {
 	return DefaultClient.GetJWKSURL(clientID)
 }
+
+func GetLogoutURL(opts GetLogoutURLOpts) (*url.URL, error) {
+	return DefaultClient.GetLogoutURL(opts)
+}

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -259,3 +259,7 @@ func RevokeInvitation(
 ) (Invitation, error) {
 	return DefaultClient.RevokeInvitation(ctx, opts)
 }
+
+func GetJWKSURL(clientID string) (*url.URL, error) {
+	return DefaultClient.GetJWKSURL(clientID)
+}

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -316,6 +316,8 @@ func TestUserManagementAuthenticateWithCode(t *testing.T) {
 			Email:     "employee@foo-corp.com",
 		},
 		OrganizationID: "org_123",
+		AccessToken:    "access_token",
+		RefreshToken:   "refresh_token",
 	}
 
 	authenticationRes, err := AuthenticateWithCode(context.Background(), AuthenticateWithCodeOpts{})
@@ -341,6 +343,8 @@ func TestUserManagementAuthenticateWithPassword(t *testing.T) {
 			Email:     "employee@foo-corp.com",
 		},
 		OrganizationID: "org_123",
+		AccessToken:    "access_token",
+		RefreshToken:   "refresh_token",
 	}
 
 	authenticationRes, err := AuthenticateWithPassword(context.Background(), AuthenticateWithPasswordOpts{})
@@ -366,6 +370,8 @@ func TestUserManagementAuthenticateWithMagicAuth(t *testing.T) {
 			Email:     "employee@foo-corp.com",
 		},
 		OrganizationID: "org_123",
+		AccessToken:    "access_token",
+		RefreshToken:   "refresh_token",
 	}
 
 	authenticationRes, err := AuthenticateWithMagicAuth(context.Background(), AuthenticateWithMagicAuthOpts{})
@@ -391,6 +397,8 @@ func TestUserManagementAuthenticateWithTOTP(t *testing.T) {
 			Email:     "employee@foo-corp.com",
 		},
 		OrganizationID: "org_123",
+		AccessToken:    "access_token",
+		RefreshToken:   "refresh_token",
 	}
 
 	authenticationRes, err := AuthenticateWithTOTP(context.Background(), AuthenticateWithTOTPOpts{})
@@ -416,6 +424,8 @@ func TestUserManagementAuthenticateWithEmailVerificationCode(t *testing.T) {
 			Email:     "employee@foo-corp.com",
 		},
 		OrganizationID: "org_123",
+		AccessToken:    "access_token",
+		RefreshToken:   "refresh_token",
 	}
 
 	authenticationRes, err := AuthenticateWithEmailVerificationCode(context.Background(), AuthenticateWithEmailVerificationCodeOpts{})
@@ -441,6 +451,8 @@ func TestUserManagementAuthenticateWithOrganizationSelection(t *testing.T) {
 			Email:     "employee@foo-corp.com",
 		},
 		OrganizationID: "org_123",
+		AccessToken:    "access_token",
+		RefreshToken:   "refresh_token",
 	}
 
 	authenticationRes, err := AuthenticateWithOrganizationSelection(context.Background(), AuthenticateWithOrganizationSelectionOpts{})

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -755,3 +755,15 @@ func TestUsersRevokeInvitation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, revokeRes)
 }
+
+func TestUserManagementGetJWKSURL(t *testing.T) {
+	client := NewClient("test")
+
+	u, err := client.GetJWKSURL("client_123")
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"https://api.workos.com/sso/jwks/client_123",
+		u.String(),
+	)
+}

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -767,3 +767,15 @@ func TestUserManagementGetJWKSURL(t *testing.T) {
 		u.String(),
 	)
 }
+
+func TestUsersManagementGetLogoutURL(t *testing.T) {
+	client := NewClient("test")
+
+	u, err := client.GetLogoutURL(GetLogoutURLOpts{SessionID: "session_abc"})
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"https://api.workos.com/user_management/sessions/logout?session_id=session_abc",
+		u.String(),
+	)
+}

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -779,3 +779,19 @@ func TestUsersManagementGetLogoutURL(t *testing.T) {
 		u.String(),
 	)
 }
+
+func TestUsersRevokeSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(RevokeSessionTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	err := RevokeSession(context.Background(), RevokeSessionOpts{
+		SessionID: "session_123",
+	})
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Description

Adds the types/endpoints necessary for dealing with sessions.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
