### PR TITLE
Add session.created event

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -43,6 +43,7 @@ const (
 	OrganizationMembershipAdded   = "organization_membership.added"
 	OrganizationMembershipUpdated = "organization_membership.updated"
 	OrganizationMembershipRemoved = "organization_membership.removed"
+	SessionCreated                = "session.created"
 )
 
 // Client represents a client that performs Event requests to the WorkOS API.


### PR DESCRIPTION
## Description
Adds `session.created` event

https://linear.app/workos/issue/DAAP-425/add-sessioncreated-to-go

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
