### PR TITLE
Add GitHub Actions as the CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test Go ${{ matrix.go }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 'stable'
+          - 'oldstable'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Run Tests
+        run: |
+          go mod download
+          go test -v ./...
+
+      - name: Code style
+        run: |
+          gofmt -d ./
+          git diff --exit-code


### PR DESCRIPTION
## Description
We are working on consolidating all CI to GitHub Actions.

The `setup-go` action supports `stable` and `oldstable` which ensure this will always build against the 2 most recent major versions of the language.


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
