### PR TITLE
User management connID and OrgID updates

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -728,10 +728,10 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOpts) (*url.URL, er
 		query.Set("provider", string(opts.Provider))
 	}
 	if opts.ConnectionID != "" {
-		query.Set("connection", opts.ConnectionID)
+		query.Set("connection_id", opts.ConnectionID)
 	}
 	if opts.OrganizationID != "" {
-		query.Set("organization", opts.OrganizationID)
+		query.Set("organization_id", opts.OrganizationID)
 	}
 	if opts.LoginHint != "" {
 		query.Set("login_hint", opts.LoginHint)


### PR DESCRIPTION
## Description
Usermanagement params for connection and organization differ from SSO api, it expects connection_id and organization_id but it still is passing connection and organization, this would update those fields to work properly. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
