### PR TITLE
Add `role_slug` to user management send invitation flow

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.4.0"
+	Version = "v4.5.0"
 )

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -451,6 +451,7 @@ type SendInvitationOpts struct {
 	OrganizationID string `json:"organization_id,omitempty"`
 	ExpiresInDays  int    `json:"expires_in_days,omitempty"`
 	InviterUserID  string `json:"inviter_user_id,omitempty"`
+	RoleSlug       string `json:"role_slug,omitempty"`
 }
 
 type RevokeInvitationOpts struct {

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -2285,6 +2285,7 @@ func TestSendInvitation(t *testing.T) {
 				OrganizationID: "org_123",
 				ExpiresInDays:  7,
 				InviterUserID:  "user_123",
+				RoleSlug:       "admin",
 			},
 			expected: Invitation{
 				ID:        "invitation_123",

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -762,7 +762,7 @@ func TestUsersSendInvitation(t *testing.T) {
 		OrganizationID: "org_123",
 		ExpiresInDays:  7,
 		InviterUserID:  "user_123",
-    RoleSlug:       "admin",
+                RoleSlug:       "admin",
 	})
 
 	require.NoError(t, err)

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -762,6 +762,7 @@ func TestUsersSendInvitation(t *testing.T) {
 		OrganizationID: "org_123",
 		ExpiresInDays:  7,
 		InviterUserID:  "user_123",
+    RoleSlug:       "admin",
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Description
`role_slug` is an optional parameter when sending an invite

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
