### PR TITLE
Add 'password_hash' and 'password_hash_type' to User creation

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.4.1"
+	Version = "v4.4.2"
 )

--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.4.2"
+	Version = "v4.4.1"
 )

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -173,11 +173,13 @@ type ListUsersOpts struct {
 }
 
 type CreateUserOpts struct {
-	Email         string `json:"email"`
-	Password      string `json:"password,omitempty"`
-	FirstName     string `json:"first_name,omitempty"`
-	LastName      string `json:"last_name,omitempty"`
-	EmailVerified bool   `json:"email_verified,omitempty"`
+	Email            string           `json:"email"`
+	Password         string           `json:"password,omitempty"`
+	PasswordHash     string           `json:"password_hash,omitempty"`
+	PasswordHashType PasswordHashType `json:"password_hash_type,omitempty"`
+	FirstName        string           `json:"first_name,omitempty"`
+	LastName         string           `json:"last_name,omitempty"`
+	EmailVerified    bool             `json:"email_verified,omitempty"`
 }
 
 // The algorithm originally used to hash the password.

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -107,6 +107,37 @@ func TestUserManagementCreateUser(t *testing.T) {
 	require.Equal(t, expectedResponse, userRes)
 }
 
+func TestUserManagementCreateUserPasswordHash(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(createUserTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := User{
+		ID:            "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
+		Email:         "marcelina@foo-corp.com",
+		FirstName:     "Marcelina",
+		LastName:      "Davis",
+		EmailVerified: true,
+		CreatedAt:     "2021-06-25T19:07:33.155Z",
+		UpdatedAt:     "2021-06-25T19:07:33.155Z",
+	}
+
+	userRes, err := CreateUser(context.Background(), CreateUserOpts{
+		Email:            "marcelina@gmail.com",
+		FirstName:        "Marcelina",
+		LastName:         "Davis",
+		EmailVerified:    true,
+		PasswordHash:     "$2b$10$dXS6RadWKYIqs6vOwqKZceLuCIqz6S81t06.yOkGJbbfeO9go4fai",
+		PasswordHashType: "bcrypt",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, userRes)
+}
+
 func TestUserManagementUpdateUser(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(updateUserTestHandler))
 	defer server.Close()


### PR DESCRIPTION
## Description
This PR ensures that the User create process allows for the `password_hash` and `password_hash_type` fields, in addition to the existing `password` field, similar to the Update process.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/26060
