### PR TITLE
Make events parameter required for ListEvents

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.6.0"
+	Version = "v4.5.0"
 )

--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.5.0"
+	Version = "v4.6.0"
 )

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -89,7 +89,7 @@ type Event struct {
 // ListEventsOpts contains the options to request provisioned Events.
 type ListEventsOpts struct {
 	// Filter to only return Events of particular types.
-	Events []string `url:"events,omitempty"`
+	Events []string `url:"events"`
 
 	// Maximum number of records to return.
 	Limit int `url:"limit"`

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -37,7 +37,7 @@ func TestListEvents(t *testing.T) {
 		}
 
 		params := ListEventsOpts{
-			Events: []string{"dsync.user.created"}
+			Events: []string{"dsync.user.created"},
 		}
 		events, err := client.ListEvents(context.Background(), params)
 
@@ -59,7 +59,7 @@ func TestListEvents(t *testing.T) {
 		rangeEnd := currentTime.AddDate(0, 0, -1)
 
 		params := ListEventsOpts{
-			Events: []string{"dsync.user.created"}
+			Events:     []string{"dsync.user.created"},
 			RangeStart: rangeStart.String(),
 			RangeEnd:   rangeEnd.String(),
 		}

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -36,7 +36,10 @@ func TestListEvents(t *testing.T) {
 			},
 		}
 
-		events, err := client.ListEvents(context.Background(), ListEventsOpts{})
+		params := ListEventsOpts{
+			Events: []string{"dsync.user.created"}
+		}
+		events, err := client.ListEvents(context.Background(), params)
 
 		require.NoError(t, err)
 		require.Equal(t, expectedResponse, events)
@@ -56,6 +59,7 @@ func TestListEvents(t *testing.T) {
 		rangeEnd := currentTime.AddDate(0, 0, -1)
 
 		params := ListEventsOpts{
+			Events: []string{"dsync.user.created"}
 			RangeStart: rangeStart.String(),
 			RangeEnd:   rangeEnd.String(),
 		}

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -21,6 +21,10 @@ func TestEventsListEvents(t *testing.T) {
 	}
 	SetAPIKey("test")
 
+	params := ListEventsOpts{
+		Events: []string{"dsync.user.created"}
+	}
+
 	expectedResponse := ListEventsResponse{
 		Data: []Event{
 			{
@@ -33,7 +37,7 @@ func TestEventsListEvents(t *testing.T) {
 			After: "",
 		},
 	}
-	eventsResponse, err := ListEvents(context.Background(), ListEventsOpts{})
+	eventsResponse, err := ListEvents(context.Background(), params)
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, eventsResponse)

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -22,7 +22,7 @@ func TestEventsListEvents(t *testing.T) {
 	SetAPIKey("test")
 
 	params := ListEventsOpts{
-		Events: []string{"dsync.user.created"}
+		Events: []string{"dsync.user.created"},
 	}
 
 	expectedResponse := ListEventsResponse{


### PR DESCRIPTION
## Description
Make events parameter required for ListEvents.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
https://github.com/workos/workos/pull/26139