### PR TITLE
Add om.created and om.deleted event types

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -40,9 +40,11 @@ const (
 	UserCreated                   = "user.created"
 	UserUpdated                   = "user.updated"
 	UserDeleted                   = "user.deleted"
-	OrganizationMembershipAdded   = "organization_membership.added"
+	OrganizationMembershipAdded   = "organization_membership.added" // Deprecated: use OrganizationMembershipCreated instead
+	OrganizationMembershipCreated = "organization_membership.created"
+	OrganizationMembershipDeleted = "organization_membership.deleted"
 	OrganizationMembershipUpdated = "organization_membership.updated"
-	OrganizationMembershipRemoved = "organization_membership.removed"
+	OrganizationMembershipRemoved = "organization_membership.removed" // Deprecated: use OrganizationMembershipDeleted instead
 	SessionCreated                = "session.created"
 )
 


### PR DESCRIPTION
## Description
Add om.created and om.deleted event types and mark om.added and om.removed as deprecated.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
