### PR TITLE
Add OrganizationId parameter to Events API

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -102,6 +102,9 @@ type ListEventsOpts struct {
 
 	// Date range end for stream of Events.
 	RangeEnd string `url:"range_end,omitempty"`
+
+
+	OrganizationId string `url:"organization_id,omitempty"`
 }
 
 // GetEventsResponse describes the response structure when requesting

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -103,7 +103,6 @@ type ListEventsOpts struct {
 	// Date range end for stream of Events.
 	RangeEnd string `url:"range_end,omitempty"`
 
-
 	OrganizationId string `url:"organization_id,omitempty"`
 }
 

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -83,7 +83,7 @@ func TestListEvents(t *testing.T) {
 		require.Equal(t, expectedResponse, events)
 	})
 
-	t.Run("ListEvents succeeds to fetch Events with an organizationId ", func(t *testing.T) {
+	t.Run("ListEvents succeeds to fetch Events with an organization_id", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(ListEventsTestHandler))
 		defer server.Close()
 		client := &Client{

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -82,6 +82,39 @@ func TestListEvents(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expectedResponse, events)
 	})
+
+	t.Run("ListEvents succeeds to fetch Events with an organizationId ", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(ListEventsTestHandler))
+		defer server.Close()
+		client := &Client{
+			HTTPClient: server.Client(),
+			Endpoint:   server.URL,
+			APIKey:     "test",
+		}
+
+		params := ListEventsOpts{
+			Events:     []string{"dsync.user.created"},
+			OrganizationId: "org_1234",
+		}
+
+		expectedResponse := ListEventsResponse{
+			Data: []Event{
+				{
+					ID:    "event_abcd1234",
+					Event: "dsync.user.created",
+					Data:  json.RawMessage(`{"foo":"bar"}`),
+				},
+			},
+			ListMetadata: common.ListMetadata{
+				After: "",
+			},
+		}
+
+		events, err := client.ListEvents(context.Background(), params)
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResponse, events)
+	})
 }
 
 func ListEventsTestHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description
Including OrganizationId as an optional parameter
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
