### PR TITLE
Add events and API changes for invitations and Magic Auth

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -46,6 +46,8 @@ const (
 	OrganizationMembershipUpdated = "organization_membership.updated"
 	OrganizationMembershipRemoved = "organization_membership.removed" // Deprecated: use OrganizationMembershipDeleted instead
 	SessionCreated                = "session.created"
+	InvitationCreated             = "invitation.created"
+	MagicAuthCreated              = "magic_auth.created"
 )
 
 // Client represents a client that performs Event requests to the WorkOS API.

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -1312,7 +1312,7 @@ func (c *Client) ResetPassword(ctx context.Context, opts ResetPasswordOpts) (Use
 	return body, err
 }
 
-// GetMagicAuth fetches an Invitation by its ID.
+// GetMagicAuth fetches a Magic Auth object by its ID.
 func (c *Client) GetMagicAuth(ctx context.Context, opts GetMagicAuthOpts) (MagicAuth, error) {
 	endpoint := fmt.Sprintf("%s/user_management/magic_auth/%s", c.Endpoint, opts.MagicAuth)
 

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -1381,7 +1381,7 @@ func (c *Client) CreateMagicAuth(ctx context.Context, opts CreateMagicAuthOpts) 
 	return body, err
 }
 
-// Deprecated: Use CreateMagicAuth instead
+// Deprecated: Use CreateMagicAuth instead. This method will be removed in a future major version.
 func (c *Client) SendMagicAuthCode(ctx context.Context, opts SendMagicAuthCodeOpts) error {
 	endpoint := fmt.Sprintf(
 		"%s/user_management/magic_auth/send",

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -191,7 +191,7 @@ func CreateMagicAuth(
 	return DefaultClient.CreateMagicAuth(ctx, opts)
 }
 
-// Deprecated: Use CreateMagicAuth instead
+// Deprecated: Use CreateMagicAuth instead. This method will be removed in a future major version.
 func SendMagicAuthCode(
 	ctx context.Context,
 	opts SendMagicAuthCodeOpts,

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -176,7 +176,22 @@ func ResetPassword(
 	return DefaultClient.ResetPassword(ctx, opts)
 }
 
-// SendMagicAuthCode sends a one-time code to the user's email address.
+func GetMagicAuth(
+	ctx context.Context,
+	opts GetMagicAuthOpts,
+) (MagicAuth, error) {
+	return DefaultClient.GetMagicAuth(ctx, opts)
+}
+
+// CreateMagicAuth creates a one-time code that can be sent to the user's email address and used for authentication.
+func CreateMagicAuth(
+	ctx context.Context,
+	opts CreateMagicAuthOpts,
+) (MagicAuth, error) {
+	return DefaultClient.CreateMagicAuth(ctx, opts)
+}
+
+// Deprecated: Use CreateMagicAuth instead
 func SendMagicAuthCode(
 	ctx context.Context,
 	opts SendMagicAuthCodeOpts,

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -492,6 +492,58 @@ func TestUserManagementAuthenticateWithOrganizationSelection(t *testing.T) {
 	require.Equal(t, expectedResponse, authenticationRes)
 }
 
+func TestUsersGetMagicAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(getMagicAuthTestHandler))
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+	SetAPIKey("test")
+
+	expectedResponse := MagicAuth{
+		ID:        "magic_auth_123",
+		UserId:    "user_123",
+		Email:     "marcelina@foo-corp.com",
+		ExpiresAt: "2021-06-25T19:07:33.155Z",
+		Code:      "123456",
+		CreatedAt: "2021-06-25T19:07:33.155Z",
+		UpdatedAt: "2021-06-25T19:07:33.155Z",
+	}
+
+	getByIDRes, err := GetMagicAuth(context.Background(), GetMagicAuthOpts{
+		MagicAuth: "magic_auth_123",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, getByIDRes)
+}
+
+func TestUserManagementCreateMagicAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(CreateMagicAuthTestHandler))
+
+	defer server.Close()
+
+	DefaultClient = mockClient(server)
+
+	SetAPIKey("test")
+
+	expectedResponse := MagicAuth{
+		ID:        "magic_auth_123",
+		UserId:    "user_123",
+		Email:     "marcelina@foo-corp.com",
+		ExpiresAt: "2021-06-25T19:07:33.155Z",
+		Code:      "123456",
+		CreatedAt: "2021-06-25T19:07:33.155Z",
+		UpdatedAt: "2021-06-25T19:07:33.155Z",
+	}
+
+	createRes, err := CreateMagicAuth(context.Background(), CreateMagicAuthOpts{
+		Email: "marcelina@foo-corp.com",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, createRes)
+}
+
 func TestUserManagementSendMagicAuthCode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(sendMagicAuthCodeTestHandler))
 
@@ -719,13 +771,14 @@ func TestUsersGetInvitation(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := Invitation{
-		ID:        "invitation_123",
-		Email:     "marcelina@foo-corp.com",
-		State:     Pending,
-		Token:     "myToken",
-		ExpiresAt: "2021-06-25T19:07:33.155Z",
-		CreatedAt: "2021-06-25T19:07:33.155Z",
-		UpdatedAt: "2021-06-25T19:07:33.155Z",
+		ID:                  "invitation_123",
+		Email:               "marcelina@foo-corp.com",
+		State:               Pending,
+		Token:               "myToken",
+		AcceptInvitationUrl: "https://myauthkit.com/invite?invitation_token=myToken",
+		ExpiresAt:           "2021-06-25T19:07:33.155Z",
+		CreatedAt:           "2021-06-25T19:07:33.155Z",
+		UpdatedAt:           "2021-06-25T19:07:33.155Z",
 	}
 
 	getByIDRes, err := GetInvitation(context.Background(), GetInvitationOpts{
@@ -747,13 +800,14 @@ func TestUsersListInvitations(t *testing.T) {
 		ListInvitationsResponse{
 			Data: []Invitation{
 				{
-					ID:        "invitation_123",
-					Email:     "marcelina@foo-corp.com",
-					State:     Pending,
-					Token:     "myToken",
-					ExpiresAt: "2021-06-25T19:07:33.155Z",
-					CreatedAt: "2021-06-25T19:07:33.155Z",
-					UpdatedAt: "2021-06-25T19:07:33.155Z",
+					ID:                  "invitation_123",
+					Email:               "marcelina@foo-corp.com",
+					State:               Pending,
+					Token:               "myToken",
+					AcceptInvitationUrl: "https://myauthkit.com/invite?invitation_token=myToken",
+					ExpiresAt:           "2021-06-25T19:07:33.155Z",
+					CreatedAt:           "2021-06-25T19:07:33.155Z",
+					UpdatedAt:           "2021-06-25T19:07:33.155Z",
 				},
 			},
 			ListMetadata: common.ListMetadata{
@@ -779,13 +833,14 @@ func TestUsersSendInvitation(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := Invitation{
-		ID:        "invitation_123",
-		Email:     "marcelina@foo-corp.com",
-		State:     Pending,
-		Token:     "myToken",
-		ExpiresAt: "2021-06-25T19:07:33.155Z",
-		CreatedAt: "2021-06-25T19:07:33.155Z",
-		UpdatedAt: "2021-06-25T19:07:33.155Z",
+		ID:                  "invitation_123",
+		Email:               "marcelina@foo-corp.com",
+		State:               Pending,
+		Token:               "myToken",
+		AcceptInvitationUrl: "https://myauthkit.com/invite?invitation_token=myToken",
+		ExpiresAt:           "2021-06-25T19:07:33.155Z",
+		CreatedAt:           "2021-06-25T19:07:33.155Z",
+		UpdatedAt:           "2021-06-25T19:07:33.155Z",
 	}
 
 	createRes, err := SendInvitation(context.Background(), SendInvitationOpts{
@@ -793,7 +848,7 @@ func TestUsersSendInvitation(t *testing.T) {
 		OrganizationID: "org_123",
 		ExpiresInDays:  7,
 		InviterUserID:  "user_123",
-                RoleSlug:       "admin",
+		RoleSlug:       "admin",
 	})
 
 	require.NoError(t, err)
@@ -810,13 +865,14 @@ func TestUsersRevokeInvitation(t *testing.T) {
 	SetAPIKey("test")
 
 	expectedResponse := Invitation{
-		ID:        "invitation_123",
-		Email:     "marcelina@foo-corp.com",
-		State:     Pending,
-		Token:     "myToken",
-		ExpiresAt: "2021-06-25T19:07:33.155Z",
-		CreatedAt: "2021-06-25T19:07:33.155Z",
-		UpdatedAt: "2021-06-25T19:07:33.155Z",
+		ID:                  "invitation_123",
+		Email:               "marcelina@foo-corp.com",
+		State:               Pending,
+		Token:               "myToken",
+		AcceptInvitationUrl: "https://myauthkit.com/invite?invitation_token=myToken",
+		ExpiresAt:           "2021-06-25T19:07:33.155Z",
+		CreatedAt:           "2021-06-25T19:07:33.155Z",
+		UpdatedAt:           "2021-06-25T19:07:33.155Z",
 	}
 
 	revokeRes, err := RevokeInvitation(context.Background(), RevokeInvitationOpts{


### PR DESCRIPTION
## Description

Adds events and API changes to support sending your own emails for invitations and Magic Auth.

- Adds `AcceptInvitationUrl` to invitation object returned by API
- Adds new event types: `invitation.created` and `magic_auth.created`
- Adds new endpoints for the Magic Auth API: `GetMagicAuth` and `CreateMagicAuth`
- Deprecates current `SendMagicAuthCode` method in favor of `CreateMagicAuth`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/26691
