### PR TITLE
Add role to directory sync user

### DIFF
--- a/pkg/common/role.go
+++ b/pkg/common/role.go
@@ -1,0 +1,6 @@
+package common
+
+type RoleResponse struct {
+	// The slug of the role
+	Slug string `json:"slug"`
+}

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -131,6 +131,9 @@ type User struct {
 
 	// The User's updated at date
 	UpdatedAt string `json:"updated_at"`
+
+	// The role given to this Directory User
+	Role RoleResponse `json:"role"`
 }
 
 // ListUsersOpts contains the options to request provisioned Directory Users.

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -291,6 +291,9 @@ func TestGetUser(t *testing.T) {
 				State:            Active,
 				RawAttributes:    json.RawMessage(`{"foo":"bar"}`),
 				CustomAttributes: json.RawMessage(`{"foo":"bar"}`),
+				Role: RoleResponse{
+					Slug: "member",
+				},
 			},
 		},
 	}

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -92,11 +92,6 @@ const (
 	PendingOrganizationMembership OrganizationMembershipStatus = "pending"
 )
 
-type RoleResponse struct {
-	// The slug of the role
-	Slug string `json:"slug"`
-}
-
 // OrganizationMembership contains data about a particular OrganizationMembership.
 type OrganizationMembership struct {
 	// The Organization Membership's unique identifier.


### PR DESCRIPTION
## Description
- optional field to directory user

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
