### PR TITLE
Add Apple and Github OAuth constants

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -36,6 +36,7 @@ type ConnectionType string
 const (
 	ADFSSAML              ConnectionType = "ADFSSAML"
 	AdpOidc               ConnectionType = "AdpOidc"
+	AppleOAuth            ConnectionType = "AppleOAuth"
 	Auth0SAML             ConnectionType = "Auth0SAML"
 	AzureSAML             ConnectionType = "AzureSAML"
 	CasSAML               ConnectionType = "CasSAML"
@@ -45,6 +46,7 @@ const (
 	DuoSAML               ConnectionType = "DuoSAML"
 	GenericOIDC           ConnectionType = "GenericOIDC"
 	GenericSAML           ConnectionType = "GenericSAML"
+	GitHubOAuth           ConnectionType = "GitHubOAuth"
 	GoogleOAuth           ConnectionType = "GoogleOAuth"
 	GoogleSAML            ConnectionType = "GoogleSAML"
 	JumpCloudSAML         ConnectionType = "JumpCloudSAML"


### PR DESCRIPTION
## Description
Add the `AppleOAuth` constant so SDK users can kick off login flows with Sign in with Apple.

The `GitHubOAuth` constant was never added to this SDK, adding it too.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
