### PR TITLE
api: Deprecate `AllowProfilesOutsideOrganization` and fix passing of `DomainData`

### DIFF
--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -79,6 +79,8 @@ type Organization struct {
 
 	// Whether Connections within the Organization allow profiles that are
 	// outside of the Organization's configured User Email Domains.
+	//
+	// Deprecated: If you need to allow sign-ins from any email domain, contact support@workos.com.
 	AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
 
 	// The Organization's Domains.
@@ -148,6 +150,8 @@ type CreateOrganizationOpts struct {
 
 	// Whether Connections within the Organization allow profiles that are
 	// outside of the Organization's configured User Email Domains.
+	//
+	// Deprecated: If you need to allow sign-ins from any email domain, contact support@workos.com.
 	AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
 
 	// Domains of the Organization.
@@ -172,6 +176,8 @@ type UpdateOrganizationOpts struct {
 
 	// Whether Connections within the Organization allow profiles that are
 	// outside of the Organization's configured User Email Domains.
+	//
+	// Deprecated: If you need to allow sign-ins from any email domain, contact support@workos.com.
 	AllowProfilesOutsideOrganization bool
 
 	// Domains of the Organization.

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -334,10 +334,15 @@ func (c *Client) UpdateOrganization(ctx context.Context, opts UpdateOrganization
 		AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
 
 		// Domains of the Organization.
+		DomainData []OrganizationDomainData `json:"domain_data,omitempty"`
+
+		// Domains of the Organization.
+		//
+		// Deprecated:  Use DomainData instead.
 		Domains []string `json:"domains,omitempty"`
 	}
 
-	update_opts := UpdateOrganizationChangeOpts{opts.Name, opts.AllowProfilesOutsideOrganization, opts.Domains}
+	update_opts := UpdateOrganizationChangeOpts{opts.Name, opts.AllowProfilesOutsideOrganization, opts.DomainData, opts.Domains}
 
 	data, err := c.JSONEncode(update_opts)
 	if err != nil {

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -334,7 +334,7 @@ func (c *Client) UpdateOrganization(ctx context.Context, opts UpdateOrganization
 		AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
 
 		// Domains of the Organization.
-		Domains []string `json:"domains"`
+		Domains []string `json:"domains,omitempty"`
 	}
 
 	update_opts := UpdateOrganizationChangeOpts{opts.Name, opts.AllowProfilesOutsideOrganization, opts.Domains}


### PR DESCRIPTION
## Description

Marks the `AllowProfilesOutsideOrganization` parameter is deprecated. I also noticed that the `DomainData` field was not being properly passed through to the underlying payload struct and fixed that, too.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
