### PR TITLE
Fix struct tag

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -512,9 +512,9 @@ type ListInvitationsResponse struct {
 }
 
 type ListInvitationsOpts struct {
-	OrganizationID string `json:"organization_id,omitempty"`
+	OrganizationID string `url:"organization_id,omitempty"`
 
-	Email string `json:"email,omitempty"`
+	Email string `url:"email,omitempty"`
 
 	// Maximum number of records to return.
 	Limit int `url:"limit"`


### PR DESCRIPTION
## Description

Found a little SDK bug here. This is breaking requests with the `GET /user_management/invitations` endpoint. Currently the SDK does not have the correct struct tags for the `ListInvitationsOpts` struct. 

Before:
<img width="1496" alt="Screenshot 2024-06-18 at 16 24 15" src="https://github.com/workos/workos-go/assets/894178/69a544a3-bd2d-436d-9cea-d5ede55d8494">

After:
<img width="1498" alt="Screenshot 2024-06-18 at 16 25 41" src="https://github.com/workos/workos-go/assets/894178/7591bbb2-be0f-43dd-9cf4-34ed44291ccc">


## Documentation

Does this require changes to the WorkOS Docs? 

> No.
