### PR TITLE
Add `OrganizationID` field to `AuthenticateWithRefreshTokenOpts`

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -258,10 +258,11 @@ type AuthenticateWithCodeOpts struct {
 }
 
 type AuthenticateWithRefreshTokenOpts struct {
-	ClientID     string `json:"client_id"`
-	RefreshToken string `json:"refresh_token"`
-	IPAddress    string `json:"ip_address,omitempty"`
-	UserAgent    string `json:"user_agent,omitempty"`
+	ClientID       string `json:"client_id"`
+	RefreshToken   string `json:"refresh_token"`
+	OrganizationID string `json:"organization_id,omitempty"`
+	IPAddress      string `json:"ip_address,omitempty"`
+	UserAgent      string `json:"user_agent,omitempty"`
 }
 
 type AuthenticateWithMagicAuthOpts struct {


### PR DESCRIPTION
## Description

Adds support for the optional `organization_id` parameter when using the `refresh_token` grant type.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
