### PR TITLE
v4.18.0

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.17.0"
+	Version = "v4.18.0"
 )


### PR DESCRIPTION
## Description

Release a `v4.18.0` version which includes:
- https://github.com/workos/workos-go/pull/356

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
