### PR TITLE
Add certificate renewal intent

### DIFF
--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -67,7 +67,7 @@ const (
 	DSync      GenerateLinkIntent = "dsync"
 	AuditLogs  GenerateLinkIntent = "audit_logs"
 	LogStreams GenerateLinkIntent = "log_streams"
-	CertificateReneawl GenerateLinkIntent = "certificate_renewal"
+	CertificateRenewal GenerateLinkIntent = "certificate_renewal"
 )
 
 // GenerateLinkOpts contains the options to request Organizations.

--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -67,6 +67,7 @@ const (
 	DSync      GenerateLinkIntent = "dsync"
 	AuditLogs  GenerateLinkIntent = "audit_logs"
 	LogStreams GenerateLinkIntent = "log_streams"
+	CertificateReneawl GenerateLinkIntent = "certificate_renewal"
 )
 
 // GenerateLinkOpts contains the options to request Organizations.

--- a/pkg/portal/client_test.go
+++ b/pkg/portal/client_test.go
@@ -71,6 +71,18 @@ func TestGenerateLink(t *testing.T) {
 			},
 			expected: "https://id.workos.test/portal/launch?secret=1234",
 		},
+		{
+			scenario: "Request returns link with certificate_renewal intent",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: GenerateLinkOpts{
+				Intent:       CertificateRenewal,
+				Organization: "organization_id",
+				ReturnURL:    "https://foo-corp.app.com/settings",
+			},
+			expected: "https://id.workos.test/portal/launch?secret=1234",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description
Adding the certificate renewal intent as an option for link generation

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
