### PR TITLE
Add `AuthenticationMethod` to `AuthenticateResponse`.

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -303,6 +303,21 @@ type AuthenticateWithOrganizationSelectionOpts struct {
 	UserAgent                  string `json:"user_agent,omitempty"`
 }
 
+// AuthenticationMethod represents the authentication method used to authenticate the user.
+type AuthenticationMethod string
+
+// Constants that enumerate the available authentication methods.
+const (
+	SSO                           AuthenticationMethod = "SSO"
+	Password                      AuthenticationMethod = "Password"
+	AppleOAuth                    AuthenticationMethod = "AppleOAuth"
+	GitHubOAuth                   AuthenticationMethod = "GitHubOAuth"
+	GoogleOAuth                   AuthenticationMethod = "GoogleOAuth"
+	MicrosoftOAuth                AuthenticationMethod = "MicrosoftOAuth"
+	MagicAuthAuthenticationMethod AuthenticationMethod = "MagicAuth"
+	Impersonation                 AuthenticationMethod = "Impersonation"
+)
+
 type Impersonator struct {
 	// The email address of the WorkOS Dashboard user using impersonation.
 	Email string `json:"email"`
@@ -327,6 +342,9 @@ type AuthenticateResponse struct {
 	// This RefreshToken can be used to obtain a new AccessToken using
 	// `AuthenticateWithRefreshToken`
 	RefreshToken string `json:"refresh_token"`
+
+	// The authentication method used to authenticate the user.
+	AuthenticationMethod AuthenticationMethod `json:"authentication_method"`
 
 	// Present if the authenticated user is being impersonated.
 	Impersonator *Impersonator `json:"impersonator"`


### PR DESCRIPTION
## Description
The API endpoint [`/user_management/authenticate`](https://workos.com/docs/reference/user-management/authentication/code) has been recently updated to include a field called `authentication_method` in the response.

This PR adds the new field to the `AuthenticateResponse` struct.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
