### PR TITLE
Add "role" to profile

### DIFF
--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -249,6 +249,9 @@ type Profile struct {
 	// The user last name. Can be empty.
 	LastName string `json:"last_name"`
 
+	// The role given to this user profile. Can be empty.
+	Role common.RoleResponse `json:"role"`
+
 	// The user's group memberships. Can be empty.
 	Groups []string `json:"groups"`
 

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -155,6 +155,9 @@ func TestClientGetProfileAndToken(t *testing.T) {
 				Email:          "foo@test.com",
 				FirstName:      "foo",
 				LastName:       "bar",
+				Role: common.RoleResponse{
+					Slug: "admin",
+				},
 				Groups:         []string{"Admins", "Developers"},
 				RawAttributes: map[string]interface{}{
 					"idp_id":     "123",
@@ -217,6 +220,9 @@ func profileAndTokenTestHandler(w http.ResponseWriter, r *http.Request) {
 			Email:          "foo@test.com",
 			FirstName:      "foo",
 			LastName:       "bar",
+			Role: common.RoleResponse{
+				Slug: "admin",
+			},
 			Groups:         []string{"Admins", "Developers"},
 			RawAttributes: map[string]interface{}{
 				"idp_id":     "123",
@@ -261,6 +267,9 @@ func TestClientGetProfile(t *testing.T) {
 				Email:          "foo@test.com",
 				FirstName:      "foo",
 				LastName:       "bar",
+				Role: common.RoleResponse{
+					Slug: "admin",
+				},
 				Groups:         []string{"Admins", "Developers"},
 				RawAttributes: map[string]interface{}{
 					"idp_id":     "123",
@@ -313,6 +322,9 @@ func profileTestHandler(w http.ResponseWriter, r *http.Request) {
 		Email:          "foo@test.com",
 		FirstName:      "foo",
 		LastName:       "bar",
+		Role: common.RoleResponse{
+			Slug: "admin",
+		},
 		Groups:         []string{"Admins", "Developers"},
 		RawAttributes: map[string]interface{}{
 			"idp_id":     "123",

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -34,6 +34,9 @@ func TestLogin(t *testing.T) {
 		Email:          "foo@test.com",
 		FirstName:      "foo",
 		LastName:       "bar",
+		Role: common.RoleResponse{
+			Slug: "admin",
+		},
 		Groups:         []string{"Admins", "Developers"},
 		RawAttributes: map[string]interface{}{
 			"idp_id":     "123",
@@ -166,6 +169,9 @@ func TestSsoGetProfile(t *testing.T) {
 		Email:          "foo@test.com",
 		FirstName:      "foo",
 		LastName:       "bar",
+		Role: common.RoleResponse{
+			Slug: "admin",
+		},
 		Groups:         []string{"Admins", "Developers"},
 		RawAttributes: map[string]interface{}{
 			"idp_id":     "123",


### PR DESCRIPTION
## Description

Adds "role" property to profile object.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```
[Docs update](https://linear.app/workos/issue/DSYNC-2079/add-role-to-profile-go)

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
