### PR TITLE
Fix typo on DirectoryGroupUserRemoved event

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -35,7 +35,7 @@ const (
 	DirectoryGroupUpdated     = "dsync.group.updated"
 	DirectoryGroupDeleted     = "dsync.group.deleted"
 	DirectoryGroupUserAdded   = "dsync.group.user_added"
-	DirectroyGroupUserRemoved = "dsync.group.user_removed"
+	DirectoryGroupUserRemoved = "dsync.group.user_removed"
 	// User Management Events
 	AuthenticationEmailVerificationSucceeded = "authentication.email_verification_succeeded"
 	AuthenticationMagicAuthFailed            = "authentication.magic_auth_failed"


### PR DESCRIPTION
## Description
Fix typo on the DirectoryGroupUserRemoved event 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
