### PR TITLE
Add domain_verification intent

### DIFF
--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -63,11 +63,12 @@ type GenerateLinkIntent string
 
 // Constants that enumerate the available GenerateLinkIntent types.
 const (
-	SSO        GenerateLinkIntent = "sso"
-	DSync      GenerateLinkIntent = "dsync"
-	AuditLogs  GenerateLinkIntent = "audit_logs"
-	LogStreams GenerateLinkIntent = "log_streams"
+	SSO                GenerateLinkIntent = "sso"
+	DSync              GenerateLinkIntent = "dsync"
+	AuditLogs          GenerateLinkIntent = "audit_logs"
+	LogStreams         GenerateLinkIntent = "log_streams"
 	CertificateRenewal GenerateLinkIntent = "certificate_renewal"
+	DomainVerification GenerateLinkIntent = "domain_verification"
 )
 
 // GenerateLinkOpts contains the options to request Organizations.

--- a/pkg/portal/client_test.go
+++ b/pkg/portal/client_test.go
@@ -83,6 +83,18 @@ func TestGenerateLink(t *testing.T) {
 			},
 			expected: "https://id.workos.test/portal/launch?secret=1234",
 		},
+		{
+			scenario: "Request returns link with domain_verification intent",
+			client: &Client{
+				APIKey: "test",
+			},
+			options: GenerateLinkOpts{
+				Intent:       DomainVerification,
+				Organization: "organization_id",
+				ReturnURL:    "https://foo-corp.app.com/settings",
+			},
+			expected: "https://id.workos.test/portal/launch?secret=1234",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

Adds `domain_verification` to the list of Admin Portal intents.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
