### PR TITLE
Add new organization domain fields

### DIFF
--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -84,6 +84,9 @@ type OrganizationDomain struct {
 	// The domain value
 	Domain string `json:"domain"`
 
+	// The Organization's unique identifier.
+	OrganizationID string `json:"organization_id"`
+
 	// Verification state of the domain.
 	State OrganizationDomainState `json:"state"`
 

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -63,10 +63,10 @@ func (c *Client) init() {
 type OrganizationDomainState string
 
 const (
-	// Pending        OrganizationDomainState = "pending"
-	// Verified       OrganizationDomainState = "verified"
-	Failed         OrganizationDomainState = "failed"
-	LegacyVerified OrganizationDomainState = "legacy_verified"
+	OrganizationDomainPending        OrganizationDomainState = "pending"
+	OrganizationDomainVerified       OrganizationDomainState = "verified"
+	OrganizationDomainFailed         OrganizationDomainState = "failed"
+	OrganizationDomainLegacyVerified OrganizationDomainState = "legacy_verified"
 )
 
 type OrganizationDomainVerificationStrategy string

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -60,6 +60,22 @@ func (c *Client) init() {
 	}
 }
 
+type OrganizationDomainState string
+
+const (
+	// Pending        OrganizationDomainState = "pending"
+	// Verified       OrganizationDomainState = "verified"
+	Failed         OrganizationDomainState = "failed"
+	LegacyVerified OrganizationDomainState = "legacy_verified"
+)
+
+type OrganizationDomainVerificationStrategy string
+
+const (
+	Dns    OrganizationDomainVerificationStrategy = "dns"
+	Manual OrganizationDomainVerificationStrategy = "manual"
+)
+
 // OrganizationDomain contains data about an Organization's Domains.
 type OrganizationDomain struct {
 	// The Organization Domain's unique identifier.
@@ -67,6 +83,15 @@ type OrganizationDomain struct {
 
 	// The domain value
 	Domain string `json:"domain"`
+
+	// Verification state of the domain.
+	State OrganizationDomainState `json:"state"`
+
+	// Strategy used to verify the domain.
+	VerificationStrategy OrganizationDomainVerificationStrategy `json:"verification_strategy,omitempty"`
+
+	// Token used for DNS verification.
+	VerificationToken string `json:"verification_token,omitempty"`
 }
 
 // Organization contains data about a WorkOS Organization.

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -38,9 +38,11 @@ func TestGetOrganization(t *testing.T) {
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
-					OrganizationDomain{
-						ID:     "organization_domain_id",
-						Domain: "foo-corp.com",
+					{
+						ID:             "organization_domain_id",
+						Domain:         "foo-corp.com",
+						OrganizationID: "organization_id",
+						State:          "verified",
 					},
 				},
 			},
@@ -79,9 +81,11 @@ func getOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 		Name:                             "Foo Corp",
 		AllowProfilesOutsideOrganization: false,
 		Domains: []OrganizationDomain{
-			OrganizationDomain{
-				ID:     "organization_domain_id",
-				Domain: "foo-corp.com",
+			{
+				ID:             "organization_domain_id",
+				Domain:         "foo-corp.com",
+				OrganizationID: "organization_id",
+				State:          "verified",
 			},
 		},
 	})
@@ -118,14 +122,16 @@ func TestListOrganizations(t *testing.T) {
 
 			expected: ListOrganizationsResponse{
 				Data: []Organization{
-					Organization{
+					{
 						ID:                               "organization_id",
 						Name:                             "Foo Corp",
 						AllowProfilesOutsideOrganization: false,
 						Domains: []OrganizationDomain{
-							OrganizationDomain{
-								ID:     "organization_domain_id",
-								Domain: "foo-corp.com",
+							{
+								ID:             "organization_domain_id",
+								Domain:         "foo-corp.com",
+								OrganizationID: "organization_id",
+								State:          "verified",
 							},
 						},
 					},
@@ -175,14 +181,16 @@ func listOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
 	}{
 		ListOrganizationsResponse: ListOrganizationsResponse{
 			Data: []Organization{
-				Organization{
+				{
 					ID:                               "organization_id",
 					Name:                             "Foo Corp",
 					AllowProfilesOutsideOrganization: false,
 					Domains: []OrganizationDomain{
-						OrganizationDomain{
-							ID:     "organization_domain_id",
-							Domain: "foo-corp.com",
+						{
+							ID:             "organization_domain_id",
+							Domain:         "foo-corp.com",
+							OrganizationID: "organization_id",
+							State:          "verified",
 						},
 					},
 				},
@@ -229,9 +237,11 @@ func TestCreateOrganization(t *testing.T) {
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
-					OrganizationDomain{
-						ID:     "organization_domain_id",
-						Domain: "foo-corp.com",
+					{
+						ID:             "organization_domain_id",
+						Domain:         "foo-corp.com",
+						OrganizationID: "organization_id",
+						State:          "verified",
 					},
 				},
 			},
@@ -244,7 +254,7 @@ func TestCreateOrganization(t *testing.T) {
 			options: CreateOrganizationOpts{
 				Name: "Foo Corp",
 				DomainData: []OrganizationDomainData{
-					OrganizationDomainData{
+					{
 						Domain: "foo-corp.com",
 						State:  "verified",
 					},
@@ -255,9 +265,11 @@ func TestCreateOrganization(t *testing.T) {
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
-					OrganizationDomain{
-						ID:     "organization_domain_id",
-						Domain: "foo-corp.com",
+					{
+						ID:             "organization_domain_id",
+						Domain:         "foo-corp.com",
+						OrganizationID: "organization_id",
+						State:          "verified",
 					},
 				},
 			},
@@ -346,9 +358,11 @@ func createOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
-				OrganizationDomain{
-					ID:     "organization_domain_id",
-					Domain: "foo-corp.com",
+				{
+					ID:             "organization_domain_id",
+					Domain:         "foo-corp.com",
+					OrganizationID: "organization_id",
+					State:          "verified",
 				},
 			},
 		})
@@ -390,13 +404,17 @@ func TestUpdateOrganization(t *testing.T) {
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
-					OrganizationDomain{
-						ID:     "organization_domain_id",
-						Domain: "foo-corp.com",
+					{
+						ID:             "organization_domain_id",
+						Domain:         "foo-corp.com",
+						OrganizationID: "organization_id",
+						State:          "verified",
 					},
-					OrganizationDomain{
-						ID:     "organization_domain_id_2",
-						Domain: "foo-corp.io",
+					{
+						ID:             "organization_domain_id_2",
+						Domain:         "foo-corp.io",
+						OrganizationID: "organization_id",
+						State:          "verified",
 					},
 				},
 			},
@@ -410,11 +428,11 @@ func TestUpdateOrganization(t *testing.T) {
 				Organization: "organization_id",
 				Name:         "Foo Corp",
 				DomainData: []OrganizationDomainData{
-					OrganizationDomainData{
+					{
 						Domain: "foo-corp.com",
 						State:  "verified",
 					},
-					OrganizationDomainData{
+					{
 						Domain: "foo-corp.io",
 						State:  "verified",
 					},
@@ -425,13 +443,17 @@ func TestUpdateOrganization(t *testing.T) {
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
-					OrganizationDomain{
-						ID:     "organization_domain_id",
-						Domain: "foo-corp.com",
+					{
+						ID:             "organization_domain_id",
+						Domain:         "foo-corp.com",
+						OrganizationID: "organization_id",
+						State:          "verified",
 					},
-					OrganizationDomain{
-						ID:     "organization_domain_id_2",
-						Domain: "foo-corp.io",
+					{
+						ID:             "organization_domain_id_2",
+						Domain:         "foo-corp.io",
+						OrganizationID: "organization_id",
+						State:          "verified",
 					},
 				},
 			},
@@ -497,13 +519,17 @@ func updateOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
-				OrganizationDomain{
-					ID:     "organization_domain_id",
-					Domain: "foo-corp.com",
+				{
+					ID:             "organization_domain_id",
+					Domain:         "foo-corp.com",
+					OrganizationID: "organization_id",
+					State:          "verified",
 				},
-				OrganizationDomain{
-					ID:     "organization_domain_id_2",
-					Domain: "foo-corp.io",
+				{
+					ID:             "organization_domain_id_2",
+					Domain:         "foo-corp.io",
+					OrganizationID: "organization_id",
+					State:          "verified",
 				},
 			},
 		})

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -25,9 +25,11 @@ func TestOrganizationsGetOrganization(t *testing.T) {
 		Name:                             "Foo Corp",
 		AllowProfilesOutsideOrganization: false,
 		Domains: []OrganizationDomain{
-			OrganizationDomain{
-				ID:     "organization_domain_id",
-				Domain: "foo-corp.com",
+			{
+				ID:             "organization_domain_id",
+				Domain:         "foo-corp.com",
+				OrganizationID: "organization_id",
+				State:          "verified",
 			},
 		},
 	}
@@ -51,14 +53,16 @@ func TestOrganizationsListOrganizations(t *testing.T) {
 
 	expectedResponse := ListOrganizationsResponse{
 		Data: []Organization{
-			Organization{
+			{
 				ID:                               "organization_id",
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
 				Domains: []OrganizationDomain{
-					OrganizationDomain{
-						ID:     "organization_domain_id",
-						Domain: "foo-corp.com",
+					{
+						ID:             "organization_domain_id",
+						Domain:         "foo-corp.com",
+						OrganizationID: "organization_id",
+						State:          "verified",
 					},
 				},
 			},
@@ -93,9 +97,11 @@ func TestOrganizationsCreateOrganization(t *testing.T) {
 			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
-				OrganizationDomain{
-					ID:     "organization_domain_id",
-					Domain: "foo-corp.com",
+				{
+					ID:             "organization_domain_id",
+					Domain:         "foo-corp.com",
+					OrganizationID: "organization_id",
+					State:          "verified",
 				},
 			},
 		}
@@ -126,13 +132,17 @@ func TestOrganizationsUpdateOrganization(t *testing.T) {
 			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
 			Domains: []OrganizationDomain{
-				OrganizationDomain{
-					ID:     "organization_domain_id",
-					Domain: "foo-corp.com",
+				{
+					ID:             "organization_domain_id",
+					Domain:         "foo-corp.com",
+					OrganizationID: "organization_id",
+					State:          "verified",
 				},
-				OrganizationDomain{
-					ID:     "organization_domain_id_2",
-					Domain: "foo-corp.io",
+				{
+					ID:             "organization_domain_id_2",
+					Domain:         "foo-corp.io",
+					OrganizationID: "organization_id",
+					State:          "verified",
 				},
 			},
 		}


### PR DESCRIPTION
## Description
Adds fields introduced with the domain verification product (`State`, `VerificationStrategy`, `VerificationToken`), and `OrganizationID`, which is useful for parsing organization domain events.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
