### PR TITLE
fix: added organization events

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -37,6 +37,10 @@ const (
 	DirectoryGroupUserAdded   = "dsync.group.user_added"
 	DirectoryGroupUserRemoved = "dsync.group.user_removed"
 	DirectroyGroupUserRemoved = "dsync.group.user_removed" // Deprecated: use DirectoryGroupUserRemoved instead
+	// Organization Events
+	OrganizationCreated = "organization.created"
+	OrganizationUpdated = "organization.updated"
+	OrganizationDeleted = "organization.deleted"
 	// User Management Events
 	AuthenticationEmailVerificationSucceeded = "authentication.email_verification_succeeded"
 	AuthenticationMagicAuthFailed            = "authentication.magic_auth_failed"


### PR DESCRIPTION
## Description

https://workos.com/docs/events/organization

Missing organization events in the webhook event listing.  This PR adds the events shown on that page.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
