### PR TITLE
Add `NewClient` method to `organizations` package

### DIFF
--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -46,6 +46,15 @@ type Client struct {
 	once sync.Once
 }
 
+func NewClient(apiKey string) *Client {
+	return &Client{
+		APIKey:     apiKey,
+		Endpoint:   "https://api.workos.com",
+		HTTPClient: &http.Client{Timeout: time.Second * 10},
+		JSONEncode: json.Marshal,
+	}
+}
+
 func (c *Client) init() {
 	if c.HTTPClient == nil {
 		c.HTTPClient = &http.Client{Timeout: 10 * time.Second}

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -22,14 +22,12 @@ func TestGetOrganization(t *testing.T) {
 	}{
 		{
 			scenario: "Request without API Key returns an error",
-			client:   &Client{},
+			client:   NewClient(""),
 			err:      true,
 		},
 		{
 			scenario: "Request returns an Organization",
-			client: &Client{
-				APIKey: "test",
-			},
+			client:   NewClient("test"),
 			options: GetOrganizationOpts{
 				Organization: "organization_id",
 			},
@@ -108,14 +106,12 @@ func TestListOrganizations(t *testing.T) {
 	}{
 		{
 			scenario: "Request without API Key returns an error",
-			client:   &Client{},
+			client:   NewClient(""),
 			err:      true,
 		},
 		{
 			scenario: "Request returns Organizations",
-			client: &Client{
-				APIKey: "test",
-			},
+			client:   NewClient("test"),
 			options: ListOrganizationsOpts{
 				Domains: []string{"foo-corp.com"},
 			},
@@ -220,14 +216,12 @@ func TestCreateOrganization(t *testing.T) {
 	}{
 		{
 			scenario: "Request without API Key returns an error",
-			client:   &Client{},
+			client:   NewClient(""),
 			err:      true,
 		},
 		{
 			scenario: "Request returns Organization with Domains",
-			client: &Client{
-				APIKey: "test",
-			},
+			client:   NewClient("test"),
 			options: CreateOrganizationOpts{
 				Name:    "Foo Corp",
 				Domains: []string{"foo-corp.com"},
@@ -248,9 +242,7 @@ func TestCreateOrganization(t *testing.T) {
 		},
 		{
 			scenario: "Request returns Organization with DomainData",
-			client: &Client{
-				APIKey: "test",
-			},
+			client:   NewClient("test"),
 			options: CreateOrganizationOpts{
 				Name: "Foo Corp",
 				DomainData: []OrganizationDomainData{
@@ -276,10 +268,8 @@ func TestCreateOrganization(t *testing.T) {
 		},
 		{
 			scenario: "Request with duplicate Organization Domain returns error",
-			client: &Client{
-				APIKey: "test",
-			},
-			err: true,
+			client:   NewClient("test"),
+			err:      true,
 			options: CreateOrganizationOpts{
 				Name:    "Foo Corp",
 				Domains: []string{"duplicate.com"},
@@ -287,10 +277,8 @@ func TestCreateOrganization(t *testing.T) {
 		},
 		{
 			scenario: "Idempotency Key with different event payloads returns error",
-			client: &Client{
-				APIKey: "test",
-			},
-			err: true,
+			client:   NewClient("test"),
+			err:      true,
 			options: CreateOrganizationOpts{
 				Name:           "New Corp",
 				Domains:        []string{"foo-corp.com"},
@@ -386,14 +374,12 @@ func TestUpdateOrganization(t *testing.T) {
 	}{
 		{
 			scenario: "Request without API Key returns an error",
-			client:   &Client{},
+			client:   NewClient(""),
 			err:      true,
 		},
 		{
 			scenario: "Request returns Organization with Domains",
-			client: &Client{
-				APIKey: "test",
-			},
+			client:   NewClient("test"),
 			options: UpdateOrganizationOpts{
 				Organization: "organization_id",
 				Name:         "Foo Corp",
@@ -421,9 +407,7 @@ func TestUpdateOrganization(t *testing.T) {
 		},
 		{
 			scenario: "Request returns Organization with DomainData",
-			client: &Client{
-				APIKey: "test",
-			},
+			client:   NewClient("test"),
 			options: UpdateOrganizationOpts{
 				Organization: "organization_id",
 				Name:         "Foo Corp",
@@ -460,10 +444,8 @@ func TestUpdateOrganization(t *testing.T) {
 		},
 		{
 			scenario: "Request with duplicate Organization Domain returns error",
-			client: &Client{
-				APIKey: "test",
-			},
-			err: true,
+			client:   NewClient("test"),
+			err:      true,
 			options: UpdateOrganizationOpts{
 				Organization: "organization_id",
 				Name:         "Foo Corp",


### PR DESCRIPTION
## Description

I was integrating WorkOS into my project and noticed that the `usermanagement` package had a `NewClient` method but the `organizations` package didn't. This PR adds that.

## Documentation

Does this require changes to the WorkOS Docs?  **No**

The examples in [the API Reference](https://workos.com/docs/reference) all use the default client and `SetAPIKey`.