### PR TITLE
Add list audit log actions API endpoint support

### DIFF
--- a/pkg/auditlogs/auditlogs.go
+++ b/pkg/auditlogs/auditlogs.go
@@ -64,3 +64,8 @@ func CreateExport(ctx context.Context, e CreateExportOpts) (AuditLogExport, erro
 func GetExport(ctx context.Context, e GetExportOpts) (AuditLogExport, error) {
 	return DefaultClient.GetExport(ctx, e)
 }
+
+// ListActions list all the audit log actions.
+func ListActions(ctx context.Context, opts ListActionsOpts) (ListActionsResponse, error) {
+	return DefaultClient.ListActions(ctx, opts)
+}


### PR DESCRIPTION
## Description
Add list audit log actions API endpoint support.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
