### PR TITLE
Add GET /organization/:orgId/roles support

### DIFF
--- a/pkg/organizations/organizations.go
+++ b/pkg/organizations/organizations.go
@@ -56,3 +56,11 @@ func DeleteOrganization(
 ) error {
 	return DefaultClient.DeleteOrganization(ctx, opts)
 }
+
+// ListOrganizationRoles lists roles for an Organization.
+func ListOrganizationRoles(
+	ctx context.Context,
+	opts ListOrganizationRolesOpts,
+) (ListOrganizationRolesResponse, error) {
+	return DefaultClient.ListOrganizationRoles(ctx, opts)
+}

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v4/pkg/roles"
 )
 
 func TestOrganizationsGetOrganization(t *testing.T) {
@@ -155,4 +156,45 @@ func TestOrganizationsUpdateOrganization(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, organization)
+}
+
+func TestOrganizationsListOrganizationRoles(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(listOrganizationRolesTestHandler))
+	defer server.Close()
+
+	DefaultClient = &Client{
+		HTTPClient: server.Client(),
+		Endpoint:   server.URL,
+	}
+	SetAPIKey("test")
+
+	expectedResponse := ListOrganizationRolesResponse{
+		Data: []roles.Role{
+			{
+				ID:          "role_01EHWNCE74X7JSDV0X3SZ3KJNY",
+				Name:        "Member",
+				Slug:        "member",
+				Description: "The default role for all users.",
+				Type:        roles.Environment,
+				CreatedAt:   "2024-12-01T00:00:00.000Z",
+				UpdatedAt:   "2024-12-01T00:00:00.000Z",
+			},
+			{
+				ID:          "role_01EHWNCE74X7JSDV0X3SZ3KJSE",
+				Name:        "Org. Member",
+				Slug:        "org-member",
+				Description: "The default role for org. members.",
+				Type:        roles.Organization,
+				CreatedAt:   "2024-12-02T00:00:00.000Z",
+				UpdatedAt:   "2024-12-02T00:00:00.000Z",
+			},
+		},
+	}
+
+	rolesResponse, err := ListOrganizationRoles(context.Background(), ListOrganizationRolesOpts{
+		OrganizationID: "organization_id",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, expectedResponse, rolesResponse)
 }

--- a/pkg/roles/README.md
+++ b/pkg/roles/README.md
@@ -1,0 +1,15 @@
+# roles
+
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/roles)
+
+A Go package to make requests to the WorkOS Roles API.
+
+## Install
+
+```sh
+go get -u github.com/workos/workos-go/v4/pkg/roles
+```
+
+## How it works
+
+See the [Roles API reference](https://workos.com/docs/reference/roles).

--- a/pkg/roles/client.go
+++ b/pkg/roles/client.go
@@ -1,0 +1,32 @@
+package roles
+
+// RoleType represents the type of a Role.
+type RoleType string
+
+// Constants that enumerate the type of a Role.
+const (
+	Environment  RoleType = "EnvironmentRole"
+	Organization RoleType = "OrganizationRole"
+)
+
+// Role contains data about a WorkOS Role.
+type Role struct {
+	// The Role's unique identifier.
+	ID string `json:"id"`
+
+	Name string `json:"name"`
+
+	// The Role's slug key for referencing it in code.
+	Slug string `json:"slug"`
+
+	Description string `json:"description"`
+
+	// The type of role
+	Type RoleType `json:"type"`
+
+	// The timestamp of when the Role was created.
+	CreatedAt string `json:"created_at"`
+
+	// The timestamp of when the Role was updated.
+	UpdatedAt string `json:"updated_at"`
+}


### PR DESCRIPTION
## Description
Add GET /organization/:orgId/roles support.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
