### PR TITLE
Add `ReturnTo` option to `GetLogoutURLOpts`

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -2206,6 +2206,9 @@ type GetLogoutURLOpts struct {
 	//
 	// REQUIRED
 	SessionID string
+
+	// The URL to redirect the user to after they have logged out.
+	ReturnTo string
 }
 
 func (c *Client) GetLogoutURL(opts GetLogoutURLOpts) (*url.URL, error) {
@@ -2219,7 +2222,12 @@ func (c *Client) GetLogoutURL(opts GetLogoutURLOpts) (*url.URL, error) {
 	}
 
 	query := make(url.Values, 1)
+
 	query.Set("session_id", opts.SessionID)
+	if opts.ReturnTo != "" {
+		query.Set("return_to", opts.ReturnTo)
+	}
+
 	u.RawQuery = query.Encode()
 
 	return u, nil

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -3182,6 +3182,50 @@ func TestRevokeInvitation(t *testing.T) {
 	}
 }
 
+func TestGetLogoutURL(t *testing.T) {
+	tests := []struct {
+		scenario string
+		options  GetLogoutURLOpts
+		expected string
+		err      bool
+	}{
+		{
+			scenario: "Returns the logout URL",
+			options: GetLogoutURLOpts{
+				SessionID: "session_123",
+			},
+			expected: "https://api.workos.com/user_management/sessions/logout?session_id=session_123",
+		},
+		{
+			scenario: "Returns an error if no SessionID is given",
+			options:  GetLogoutURLOpts{},
+			err:      true,
+		},
+		{
+			scenario: "Includes return_to if given",
+			options: GetLogoutURLOpts{
+				SessionID: "session_123",
+				ReturnTo:  "https://your-app.com",
+			},
+			expected: "https://api.workos.com/user_management/sessions/logout?return_to=https%3A%2F%2Fyour-app.com&session_id=session_123",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			client := NewClient("test")
+
+			url, err := client.GetLogoutURL(test.options)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, url.String())
+		})
+	}
+}
+
 func RevokeInvitationTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {


### PR DESCRIPTION
## Description

Adds a new optional `ReturnTo` option to `GetLogoutURLOpts` to support the upcoming Logout URIs feature.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
