### PR TITLE
ron: adding optional query params for PKCE flow

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -251,10 +251,11 @@ type AuthenticateWithPasswordOpts struct {
 }
 
 type AuthenticateWithCodeOpts struct {
-	ClientID  string `json:"client_id"`
-	Code      string `json:"code"`
-	IPAddress string `json:"ip_address,omitempty"`
-	UserAgent string `json:"user_agent,omitempty"`
+	ClientID     string `json:"client_id"`
+	Code         string `json:"code"`
+	CodeVerifier string `json:"code_verifier,omitempty"`
+	IPAddress    string `json:"ip_address,omitempty"`
+	UserAgent    string `json:"user_agent,omitempty"`
 }
 
 type AuthenticateWithRefreshTokenOpts struct {
@@ -836,7 +837,10 @@ type GetAuthorizationURLOpts struct {
 	//
 	// REQUIRED.
 	ClientID string
-
+	//Optional Used for PKCE
+	CodeChallenge string
+	//Optional Used for PKCE
+	CodeChallengeMethod string
 	// The callback URL where your app redirects the user after an
 	// authorization code is granted (eg. https://foo.com/callback).
 	//
@@ -895,6 +899,12 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOpts) (*url.URL, er
 	}
 	if opts.ConnectionID != "" {
 		query.Set("connection_id", opts.ConnectionID)
+	}
+	if opts.CodeChallenge != "" {
+		query.Set("code_challenge", opts.CodeChallenge)
+	}
+	if opts.CodeChallengeMethod != "" {
+		query.Set("code_challenge_method", opts.CodeChallengeMethod)
 	}
 	if opts.OrganizationID != "" {
 		query.Set("organization_id", opts.OrganizationID)

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -684,6 +684,17 @@ func TestClientAuthorizeURL(t *testing.T) {
 			},
 			expected: "https://api.workos.com/user_management/authorize?client_id=client_123&connection_id=connection_123&login_hint=foo%40workos.com&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code&state=custom+state",
 		},
+		{
+			scenario: "generate url with Code Challenge",
+			options: GetAuthorizationURLOpts{
+				ClientID:            "client_123",
+				ConnectionID:        "connection_123",
+				RedirectURI:         "https://example.com/sso/workos/callback",
+				CodeChallenge:       "code_verifier_value",
+				CodeChallengeMethod: "S256",
+			},
+			expected: "https://api.workos.com/user_management/authorize?client_id=client_123&code_challenge=code_verifier_value&code_challenge_method=S256&connection_id=connection_123&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

added query params to `GetAuthorizationURLOpts struct` and CodeVerifier to `AuthenticateWithCodeOpts struct`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
