### PR TITLE
Add email standard attribute to DirectoryUser and mark deprecated standard attributes

### DIFF
--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -99,10 +99,19 @@ type User struct {
 	// The identifier for the Organization in which the Directory resides.
 	OrganizationID string `json:"organization_id"`
 
+	// The User's primary email
+	Email string `json:"email"`
+
 	// The User's username.
+	// Deprecated: Will be removed in a future major version. Enable the `username` custom attribute
+	// in dashboard and pull from customAttributes instead. See
+	// https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
 	Username string `json:"username"`
 
 	// The User's e-mails.
+	// Deprecated: Will be removed in a future major version. Enable the `emails` custom attribute
+	// in dashboard and pull from customAttributes instead. See
+	// https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
 	Emails []UserEmail `json:"emails"`
 
 	// The User's groups.
@@ -115,6 +124,9 @@ type User struct {
 	LastName string `json:"last_name"`
 
 	// The User's job title.
+	// Deprecated: Will be removed in a future major version. Enable the `job_title` custom attribute
+	// in dashboard and pull from customAttributes instead. See
+	// https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.
 	JobTitle string `json:"job_title"`
 
 	// The User's state.

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -40,6 +40,7 @@ func TestListUsers(t *testing.T) {
 						FirstName: "Rick",
 						LastName:  "Sanchez",
 						JobTitle:  "Software Engineer",
+						Email:     "rick@sanchez.com",
 						Emails: []UserEmail{
 							UserEmail{
 								Primary: true,
@@ -112,6 +113,7 @@ func listUsersTestHandler(w http.ResponseWriter, r *http.Request) {
 					FirstName: "Rick",
 					LastName:  "Sanchez",
 					JobTitle:  "Software Engineer",
+					Email:     "rick@sanchez.com",
 					Emails: []UserEmail{
 						UserEmail{
 							Primary: true,
@@ -278,6 +280,7 @@ func TestGetUser(t *testing.T) {
 				FirstName: "Rick",
 				LastName:  "Sanchez",
 				JobTitle:  "Software Engineer",
+				Email:     "rick@sanchez.com",
 				Emails: []UserEmail{
 					UserEmail{
 						Primary: true,
@@ -337,6 +340,7 @@ func getUserTestHandler(w http.ResponseWriter, r *http.Request) {
 		FirstName: "Rick",
 		LastName:  "Sanchez",
 		JobTitle:  "Software Engineer",
+		Email:     "rick@sanchez.com",
 		Emails: []UserEmail{
 			UserEmail{
 				Primary: true,

--- a/pkg/directorysync/directorysync.go
+++ b/pkg/directorysync/directorysync.go
@@ -75,6 +75,7 @@ func DeleteDirectory(
 }
 
 // PrimaryEmail is a method for finding a user's primary email (when applicable)
+// Deprecated: Will be removed in a future major version. Use `email` attribute on User instead.
 func (r User) PrimaryEmail() (string, error) {
 	for _, v := range r.Emails {
 		if v.Primary {

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -32,6 +32,7 @@ func TestDirectorySyncListUsers(t *testing.T) {
 				FirstName: "Rick",
 				LastName:  "Sanchez",
 				JobTitle:  "Software Engineer",
+				Email:     "rick@sanchez.com",
 				Emails: []UserEmail{
 					UserEmail{
 						Primary: true,
@@ -123,6 +124,7 @@ func TestDirectorySyncGetUser(t *testing.T) {
 		FirstName: "Rick",
 		LastName:  "Sanchez",
 		JobTitle:  "Software Engineer",
+		Email:     "rick@sanchez.com",
 		Emails: []UserEmail{
 			UserEmail{
 				Primary: true,
@@ -322,6 +324,7 @@ func TestPrimaryEmail(t *testing.T) {
 				ID:        "directory_user_id",
 				FirstName: "WorkOS",
 				LastName:  "Testz",
+				Email:     "primaryemail@foo-corp.com",
 				Emails: []UserEmail{
 					UserEmail{
 						Primary: true,
@@ -348,6 +351,7 @@ func TestPrimaryEmail(t *testing.T) {
 				ID:        "directory_user_id",
 				FirstName: "WorkOS",
 				LastName:  "Testz",
+				Email:     "primaryemail@foo-corp.com",
 				Emails: []UserEmail{
 					UserEmail{
 						Primary: true,


### PR DESCRIPTION
## Description
Add email standard attribute to DirectoryUser and mark deprecated standard attributes.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
