### PR TITLE
ron: adding support for context param

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -844,6 +844,8 @@ type GetAuthorizationURLOpts struct {
 	CodeChallenge string
 	//Optional Used for PKCE
 	CodeChallengeMethod string
+
+	Context string
 	// The callback URL where your app redirects the user after an
 	// authorization code is granted (eg. https://foo.com/callback).
 	//
@@ -908,6 +910,9 @@ func (c *Client) GetAuthorizationURL(opts GetAuthorizationURLOpts) (*url.URL, er
 	}
 	if opts.CodeChallengeMethod != "" {
 		query.Set("code_challenge_method", opts.CodeChallengeMethod)
+	}
+	if opts.Context != "" {
+		query.Set("context", opts.Context)
 	}
 	if opts.OrganizationID != "" {
 		query.Set("organization_id", opts.OrganizationID)

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -707,6 +707,16 @@ func TestClientAuthorizeURL(t *testing.T) {
 			},
 			expected: "https://api.workos.com/user_management/authorize?client_id=client_123&code_challenge=code_verifier_value&code_challenge_method=S256&connection_id=connection_123&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code",
 		},
+		{
+			scenario: "generate url with Context",
+			options: GetAuthorizationURLOpts{
+				ClientID:     "client_123",
+				ConnectionID: "connection_123",
+				RedirectURI:  "https://example.com/sso/workos/callback",
+				Context:      "context=123",
+			},
+			expected: "https://api.workos.com/user_management/authorize?client_id=client_123&connection_id=connection_123&context=context%3D123&redirect_uri=https%3A%2F%2Fexample.com%2Fsso%2Fworkos%2Fcallback&response_type=code",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description
Adding support for the context param 
## Documentation
docs forth coming

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
