### PR TITLE
Adds external id and metadata to users and organizations

### DIFF
--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -123,6 +123,12 @@ type Organization struct {
 
 	// The timestamp of when the Organization was updated.
 	UpdatedAt string `json:"updated_at"`
+
+	// The Organization's external id.
+	ExternalID string `json:"external_id"`
+
+	// The Organization's metadata.
+	Metadata map[string]string `json:"metadata"`
 }
 
 // GetOrganizationOpts contains the options to request details for an Organization.
@@ -196,6 +202,12 @@ type CreateOrganizationOpts struct {
 
 	// Optional unique identifier to ensure idempotency
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
+
+	// The Organization's external id.
+	ExternalID string `json:"external_id"`
+
+	// The Organization's metadata.
+	Metadata map[string]string `json:"metadata"`
 }
 
 // UpdateOrganizationOpts contains the options to update an Organization.
@@ -219,6 +231,12 @@ type UpdateOrganizationOpts struct {
 
 	// Domains of the Organization.
 	DomainData []OrganizationDomainData `json:"domain_data"`
+
+	// The Organization's external id.
+	ExternalID string `json:"external_id"`
+
+	// The Organization's metadata.
+	Metadata map[string]string `json:"metadata"`
 }
 
 // ListOrganizationsOpts contains the options to request Organizations.

--- a/pkg/organizations/organizations.go
+++ b/pkg/organizations/organizations.go
@@ -25,6 +25,14 @@ func GetOrganization(
 	return DefaultClient.GetOrganization(ctx, opts)
 }
 
+// GetOrganization gets an Organization by its external id
+func GetOrganizationByExternalID(
+	ctx context.Context,
+	opts GetOrganizationByExternalIDOpts,
+) (Organization, error) {
+	return DefaultClient.GetOrganizationByExternalID(ctx, opts)
+}
+
 // ListOrganizations gets a list of Organizations.
 func ListOrganizations(
 	ctx context.Context,

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -36,6 +36,7 @@ func TestOrganizationsGetOrganization(t *testing.T) {
 				VerificationPrefix:   "superapp-domain-verification-0fmfet",
 			},
 		},
+		ExternalID: "external_id",
 	}
 	organizationResponse, err := GetOrganization(context.Background(), GetOrganizationOpts{
 		Organization: "org_01EHT88Z8J8795GZNQ4ZP1J81T",

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -139,7 +139,6 @@ type OrganizationMembership struct {
 
 // User contains data about a particular User.
 type User struct {
-
 	// The User's unique identifier.
 	ID string `json:"id"`
 
@@ -166,6 +165,12 @@ type User struct {
 
 	// The timestamp when the user last signed in.
 	LastSignInAt string `json:"last_sign_in_at"`
+
+	// The User's external id.
+	ExternalID string `json:"external_id"`
+
+	// The User's metadata.
+	Metadata map[string]string `json:"metadata"`
 }
 
 // Represents User identities obtained from external identity providers.
@@ -214,13 +219,15 @@ type ListUsersOpts struct {
 }
 
 type CreateUserOpts struct {
-	Email            string           `json:"email"`
-	Password         string           `json:"password,omitempty"`
-	PasswordHash     string           `json:"password_hash,omitempty"`
-	PasswordHashType PasswordHashType `json:"password_hash_type,omitempty"`
-	FirstName        string           `json:"first_name,omitempty"`
-	LastName         string           `json:"last_name,omitempty"`
-	EmailVerified    bool             `json:"email_verified,omitempty"`
+	Email            string            `json:"email"`
+	Password         string            `json:"password,omitempty"`
+	PasswordHash     string            `json:"password_hash,omitempty"`
+	PasswordHashType PasswordHashType  `json:"password_hash_type,omitempty"`
+	FirstName        string            `json:"first_name,omitempty"`
+	LastName         string            `json:"last_name,omitempty"`
+	EmailVerified    bool              `json:"email_verified,omitempty"`
+	ExternalID       string            `json:"external_id,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
 }
 
 // The algorithm originally used to hash the password.
@@ -233,12 +240,14 @@ const (
 
 type UpdateUserOpts struct {
 	User             string
-	FirstName        string           `json:"first_name,omitempty"`
-	LastName         string           `json:"last_name,omitempty"`
-	EmailVerified    bool             `json:"email_verified,omitempty"`
-	Password         string           `json:"password,omitempty"`
-	PasswordHash     string           `json:"password_hash,omitempty"`
-	PasswordHashType PasswordHashType `json:"password_hash_type,omitempty"`
+	FirstName        string            `json:"first_name,omitempty"`
+	LastName         string            `json:"last_name,omitempty"`
+	EmailVerified    bool              `json:"email_verified,omitempty"`
+	Password         string            `json:"password,omitempty"`
+	PasswordHash     string            `json:"password_hash,omitempty"`
+	PasswordHashType PasswordHashType  `json:"password_hash_type,omitempty"`
+	ExternalID       string            `json:"external_id,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
 }
 
 type DeleteUserOpts struct {

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -42,6 +42,7 @@ func TestGetUser(t *testing.T) {
 				LastSignInAt:  "2021-06-25T19:07:33.155Z",
 				CreatedAt:     "2021-06-25T19:07:33.155Z",
 				UpdatedAt:     "2021-06-25T19:07:33.155Z",
+				ExternalID:    "123",
 			},
 		},
 		{
@@ -60,6 +61,7 @@ func TestGetUser(t *testing.T) {
 				LastSignInAt:      "2021-06-25T19:07:33.155Z",
 				CreatedAt:         "2021-06-25T19:07:33.155Z",
 				UpdatedAt:         "2021-06-25T19:07:33.155Z",
+				ExternalID:        "456",
 			},
 		},
 	}
@@ -104,6 +106,7 @@ func getUserTestHandler(w http.ResponseWriter, r *http.Request) {
 			LastSignInAt:  "2021-06-25T19:07:33.155Z",
 			CreatedAt:     "2021-06-25T19:07:33.155Z",
 			UpdatedAt:     "2021-06-25T19:07:33.155Z",
+			ExternalID:    "123",
 		})
 	}
 
@@ -118,6 +121,7 @@ func getUserTestHandler(w http.ResponseWriter, r *http.Request) {
 			LastSignInAt:      "2021-06-25T19:07:33.155Z",
 			CreatedAt:         "2021-06-25T19:07:33.155Z",
 			UpdatedAt:         "2021-06-25T19:07:33.155Z",
+			ExternalID:        "456",
 		})
 	}
 

--- a/pkg/usermanagement/usermanagement.go
+++ b/pkg/usermanagement/usermanagement.go
@@ -48,6 +48,14 @@ func GetUser(
 	return DefaultClient.GetUser(ctx, opts)
 }
 
+// GetUser gets a User.
+func GetUserByExternalID(
+	ctx context.Context,
+	opts GetUserByExternalIDOpts,
+) (User, error) {
+	return DefaultClient.GetUserByExternalID(ctx, opts)
+}
+
 // ListUsers gets a list of Users.
 func ListUsers(
 	ctx context.Context,

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -36,6 +36,7 @@ func TestUserManagementGetUser(t *testing.T) {
 		LastSignInAt:  "2021-06-25T19:07:33.155Z",
 		CreatedAt:     "2021-06-25T19:07:33.155Z",
 		UpdatedAt:     "2021-06-25T19:07:33.155Z",
+		ExternalID:    "123",
 	}
 
 	userRes, err := GetUser(context.Background(), GetUserOpts{


### PR DESCRIPTION
## Description

Returns this data when retrieving users and organizations as well as updating the creation and updating of users and orgs to accept these new options.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
