### PR TITLE
Alias organization domain types

### DIFF
--- a/pkg/organization_domains/client.go
+++ b/pkg/organization_domains/client.go
@@ -53,22 +53,6 @@ type OrganizationDomain struct {
 	VerificationPrefix string `json:"verification_prefix,omitempty"`
 }
 
-type OrganizationDomainDataState string
-
-const (
-	Verified OrganizationDomainDataState = "verified"
-	Pending  OrganizationDomainDataState = "pending"
-)
-
-// OrganizationDomainData contains data used to create an OrganizationDomain.
-type OrganizationDomainData struct {
-	// The domain's value.
-	Domain string `json:"domain"`
-
-	// The domain's state.
-	State OrganizationDomainDataState `json:"state"`
-}
-
 // GetOrganizationDomainOpts contains the options to get a domain.
 type GetOrganizationDomainOpts struct {
 	DomainID string

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -64,7 +64,19 @@ func (c *Client) init() {
 
 type OrganizationDomainState = organization_domains.OrganizationDomainState
 
+const (
+	OrganizationDomainPending        OrganizationDomainState = organization_domains.OrganizationDomainPending
+	OrganizationDomainVerified       OrganizationDomainState = organization_domains.OrganizationDomainVerified
+	OrganizationDomainFailed         OrganizationDomainState = organization_domains.OrganizationDomainFailed
+	OrganizationDomainLegacyVerified OrganizationDomainState = organization_domains.OrganizationDomainLegacyVerified
+)
+
 type OrganizationDomainVerificationStrategy = organization_domains.OrganizationDomainVerificationStrategy
+
+const (
+	Dns    OrganizationDomainVerificationStrategy = organization_domains.Dns
+	Manual OrganizationDomainVerificationStrategy = organization_domains.Manual
+)
 
 type OrganizationDomain = organization_domains.OrganizationDomain
 
@@ -136,9 +148,21 @@ type ListOrganizationsResponse struct {
 	ListMetadata common.ListMetadata `json:"listMetadata"`
 }
 
-type OrganizationDomainDataState = organization_domains.OrganizationDomainDataState
+type OrganizationDomainDataState string
 
-type OrganizationDomainData = organization_domains.OrganizationDomainData
+const (
+	Verified OrganizationDomainDataState = OrganizationDomainDataState(organization_domains.OrganizationDomainVerified)
+	Pending  OrganizationDomainDataState = OrganizationDomainDataState(organization_domains.OrganizationDomainPending)
+)
+
+// OrganizationDomainData contains data used to create an OrganizationDomain.
+type OrganizationDomainData struct {
+	// The domain's value.
+	Domain string `json:"domain"`
+
+	// The domain's state.
+	State OrganizationDomainDataState `json:"state"`
+}
 
 // CreateOrganizationOpts contains the options to create an Organization.
 type CreateOrganizationOpts struct {

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -62,6 +62,12 @@ func (c *Client) init() {
 	}
 }
 
+type OrganizationDomainState = organization_domains.OrganizationDomainState
+
+type OrganizationDomainVerificationStrategy = organization_domains.OrganizationDomainVerificationStrategy
+
+type OrganizationDomain = organization_domains.OrganizationDomain
+
 // Organization contains data about a WorkOS Organization.
 type Organization struct {
 	// The Organization's unique identifier.
@@ -77,7 +83,7 @@ type Organization struct {
 	AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
 
 	// The Organization's Domains.
-	Domains []organization_domains.OrganizationDomain `json:"domains"`
+	Domains []OrganizationDomain `json:"domains"`
 
 	// The timestamp of when the Organization was created.
 	CreatedAt string `json:"created_at"`
@@ -130,21 +136,9 @@ type ListOrganizationsResponse struct {
 	ListMetadata common.ListMetadata `json:"listMetadata"`
 }
 
-type OrganizationDomainDataState string
+type OrganizationDomainDataState = organization_domains.OrganizationDomainDataState
 
-const (
-	Verified OrganizationDomainDataState = "verified"
-	Pending  OrganizationDomainDataState = "pending"
-)
-
-// OrganizationDomainData contains data used to create an OrganizationDomain.
-type OrganizationDomainData struct {
-	// The domain's value.
-	Domain string `json:"domain"`
-
-	// The domain's state.
-	State OrganizationDomainDataState `json:"state"`
-}
+type OrganizationDomainData = organization_domains.OrganizationDomainData
 
 // CreateOrganizationOpts contains the options to create an Organization.
 type CreateOrganizationOpts struct {
@@ -163,7 +157,7 @@ type CreateOrganizationOpts struct {
 	Domains []string `json:"domains"`
 
 	// Domains of the Organization.
-	DomainData []organization_domains.OrganizationDomainData `json:"domain_data"`
+	DomainData []OrganizationDomainData `json:"domain_data"`
 
 	// Optional unique identifier to ensure idempotency
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
@@ -195,7 +189,7 @@ type UpdateOrganizationOpts struct {
 	Domains []string
 
 	// Domains of the Organization.
-	DomainData []organization_domains.OrganizationDomainData `json:"domain_data"`
+	DomainData []OrganizationDomainData `json:"domain_data"`
 
 	// The Organization's external id.
 	ExternalID string `json:"external_id"`
@@ -402,7 +396,7 @@ func (c *Client) UpdateOrganization(ctx context.Context, opts UpdateOrganization
 		AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
 
 		// Domains of the Organization.
-		DomainData []organization_domains.OrganizationDomainData `json:"domain_data,omitempty"`
+		DomainData []OrganizationDomainData `json:"domain_data,omitempty"`
 
 		// Domains of the Organization.
 		//

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/organization_domains"
 	"github.com/workos/workos-go/v4/pkg/roles"
 )
 
@@ -39,7 +38,7 @@ func TestGetOrganization(t *testing.T) {
 				ID:                               "org_01EHT88Z8J8795GZNQ4ZP1J81T",
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
-				Domains: []organization_domains.OrganizationDomain{
+				Domains: []OrganizationDomain{
 					{
 						ID:                   "org_domain_01HEJXJSTVEDT7T58BM70FMFET",
 						Domain:               "foo-corp.com",
@@ -100,7 +99,7 @@ func TestGetOrganizationByExternalID(t *testing.T) {
 				ID:                               "org_01EHT88Z8J8795GZNQ4ZP1J81T",
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
-				Domains: []organization_domains.OrganizationDomain{
+				Domains: []OrganizationDomain{
 					{
 						ID:                   "org_domain_01HEJXJSTVEDT7T58BM70FMFET",
 						Domain:               "foo-corp.com",
@@ -147,7 +146,7 @@ func getOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 		ID:                               "org_01EHT88Z8J8795GZNQ4ZP1J81T",
 		Name:                             "Foo Corp",
 		AllowProfilesOutsideOrganization: false,
-		Domains: []organization_domains.OrganizationDomain{
+		Domains: []OrganizationDomain{
 			{
 				ID:                   "org_domain_01HEJXJSTVEDT7T58BM70FMFET",
 				Domain:               "foo-corp.com",
@@ -197,7 +196,7 @@ func TestListOrganizations(t *testing.T) {
 						ID:                               "organization_id",
 						Name:                             "Foo Corp",
 						AllowProfilesOutsideOrganization: false,
-						Domains: []organization_domains.OrganizationDomain{
+						Domains: []OrganizationDomain{
 							{
 								ID:             "organization_domain_id",
 								Domain:         "foo-corp.com",
@@ -256,7 +255,7 @@ func listOrganizationsTestHandler(w http.ResponseWriter, r *http.Request) {
 					ID:                               "organization_id",
 					Name:                             "Foo Corp",
 					AllowProfilesOutsideOrganization: false,
-					Domains: []organization_domains.OrganizationDomain{
+					Domains: []OrganizationDomain{
 						{
 							ID:             "organization_domain_id",
 							Domain:         "foo-corp.com",
@@ -307,7 +306,7 @@ func TestCreateOrganization(t *testing.T) {
 				ID:                               "organization_id",
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
-				Domains: []organization_domains.OrganizationDomain{
+				Domains: []OrganizationDomain{
 					{
 						ID:             "organization_domain_id",
 						Domain:         "foo-corp.com",
@@ -324,7 +323,7 @@ func TestCreateOrganization(t *testing.T) {
 			},
 			options: CreateOrganizationOpts{
 				Name: "Foo Corp",
-				DomainData: []organization_domains.OrganizationDomainData{
+				DomainData: []OrganizationDomainData{
 					{
 						Domain: "foo-corp.com",
 						State:  "verified",
@@ -335,7 +334,7 @@ func TestCreateOrganization(t *testing.T) {
 				ID:                               "organization_id",
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
-				Domains: []organization_domains.OrganizationDomain{
+				Domains: []OrganizationDomain{
 					{
 						ID:             "organization_domain_id",
 						Domain:         "foo-corp.com",
@@ -428,7 +427,7 @@ func createOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 			ID:                               "organization_id",
 			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
-			Domains: []organization_domains.OrganizationDomain{
+			Domains: []OrganizationDomain{
 				{
 					ID:             "organization_domain_id",
 					Domain:         "foo-corp.com",
@@ -474,7 +473,7 @@ func TestUpdateOrganization(t *testing.T) {
 				ID:                               "organization_id",
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
-				Domains: []organization_domains.OrganizationDomain{
+				Domains: []OrganizationDomain{
 					{
 						ID:             "organization_domain_id",
 						Domain:         "foo-corp.com",
@@ -498,7 +497,7 @@ func TestUpdateOrganization(t *testing.T) {
 			options: UpdateOrganizationOpts{
 				Organization: "organization_id",
 				Name:         "Foo Corp",
-				DomainData: []organization_domains.OrganizationDomainData{
+				DomainData: []OrganizationDomainData{
 					{
 						Domain: "foo-corp.com",
 						State:  "verified",
@@ -513,7 +512,7 @@ func TestUpdateOrganization(t *testing.T) {
 				ID:                               "organization_id",
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
-				Domains: []organization_domains.OrganizationDomain{
+				Domains: []OrganizationDomain{
 					{
 						ID:             "organization_domain_id",
 						Domain:         "foo-corp.com",
@@ -589,7 +588,7 @@ func updateOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 			ID:                               "organization_id",
 			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
-			Domains: []organization_domains.OrganizationDomain{
+			Domains: []OrganizationDomain{
 				{
 					ID:             "organization_domain_id",
 					Domain:         "foo-corp.com",

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/organization_domains"
 	"github.com/workos/workos-go/v4/pkg/roles"
 )
 
@@ -26,7 +25,7 @@ func TestOrganizationsGetOrganization(t *testing.T) {
 		ID:                               "org_01EHT88Z8J8795GZNQ4ZP1J81T",
 		Name:                             "Foo Corp",
 		AllowProfilesOutsideOrganization: false,
-		Domains: []organization_domains.OrganizationDomain{
+		Domains: []OrganizationDomain{
 			{
 				ID:                   "org_domain_01HEJXJSTVEDT7T58BM70FMFET",
 				Domain:               "foo-corp.com",
@@ -63,7 +62,7 @@ func TestOrganizationsListOrganizations(t *testing.T) {
 				ID:                               "organization_id",
 				Name:                             "Foo Corp",
 				AllowProfilesOutsideOrganization: false,
-				Domains: []organization_domains.OrganizationDomain{
+				Domains: []OrganizationDomain{
 					{
 						ID:             "organization_domain_id",
 						Domain:         "foo-corp.com",
@@ -102,7 +101,7 @@ func TestOrganizationsCreateOrganization(t *testing.T) {
 			ID:                               "organization_id",
 			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
-			Domains: []organization_domains.OrganizationDomain{
+			Domains: []OrganizationDomain{
 				{
 					ID:             "organization_domain_id",
 					Domain:         "foo-corp.com",
@@ -137,7 +136,7 @@ func TestOrganizationsUpdateOrganization(t *testing.T) {
 			ID:                               "organization_id",
 			Name:                             "Foo Corp",
 			AllowProfilesOutsideOrganization: false,
-			Domains: []organization_domains.OrganizationDomain{
+			Domains: []OrganizationDomain{
 				{
 					ID:             "organization_domain_id",
 					Domain:         "foo-corp.com",


### PR DESCRIPTION
## Description

The [PR](https://github.com/workos/workos-go/pull/412) that added the `organization_domains` package moved the domain types to `organization_domains` from `organizations`. To prevent a major version bump and a breaking change, this PR aliases the moved types so they are still available via the `organizations` package

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
