### PR TITLE
add password_reset.succeeded event type

### DIFF
--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -65,6 +65,7 @@ const (
 	InvitationCreated                        = "invitation.created"
 	MagicAuthCreated                         = "magic_auth.created"
 	PasswordResetCreated                     = "password_reset.created"
+	PasswordResetSucceeded                   = "password_reset.succeeded"
 	// Organization Domain Events
 	OrganizationDomainVerified           = "organization_domain.verified"
 	OrganizationDomainVerificationFailed = "organization_domain.verification_failed"


### PR DESCRIPTION
## Description
https://linear.app/workos/issue/AUTH-4439/add-password-resetsucceeded-event-to-go-sdk

adds support for `password_reset.succeeded` event type

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
