### PR TITLE
Support optional authenticated data in local encrypt/decrypt

### DIFF
--- a/pkg/vault/cryptography_test.go
+++ b/pkg/vault/cryptography_test.go
@@ -55,7 +55,7 @@ func TestLocalDecrypt(t *testing.T) {
 	require.Equal(t, iv, decoded.Iv)
 	require.Equal(t, authTag, decoded.Tag)
 
-	plaintext, err := LocalDecrypt(decoded, dataKey)
+	plaintext, err := LocalDecrypt(decoded, dataKey, "")
 	require.NoError(t, err)
 	require.Equal(t, expected, plaintext)
 }
@@ -68,13 +68,37 @@ func TestLocalEncryptAndDecrypt(t *testing.T) {
 	}
 	data := "super secret access codes"
 
-	ciphertext, err := LocalEncrypt(data, keyPair)
+	ciphertext, err := LocalEncrypt(data, keyPair, "")
 	require.NoError(t, err)
 
 	decoded, err := Decode(ciphertext)
 	require.NoError(t, err)
 
-	plaintext, err := LocalDecrypt(decoded, DataKey{Id: keyPair.Id, Key: keyPair.DataKey})
+	plaintext, err := LocalDecrypt(decoded, DataKey{Id: keyPair.Id, Key: keyPair.DataKey}, "")
+	require.NoError(t, err)
+	require.Equal(t, data, plaintext)
+}
+
+func TestLocalEncryptWithAssociatedData(t *testing.T) {
+	keyPair := DataKeyPair{
+		DataKey:       "hNjAWl++MJjDZ64dUeYlgJZDEbemRmdKvNHUnnRFUNg=",
+		Id:            "0205e0ec-828e-5594-96ac-a68fc8257fb7",
+		EncryptedKeys: "V09TLkVLTS52MQAwMjA1ZTBlYy04MjhlLTU1OTQtOTZhYy1hNjhmYzgyNTdmYjcBATEBJGNmMjllNjhhLWYzMmQtNDI4YS05NDg2LTY5YjAyM2JmNjUyNAF0Y2YyOWU2OGEtZjMyZC00MjhhLTk0ODYtNjliMDIzYmY2NTI0uRXneWi4j8iJN4vYJQfGWJVDhk3ogkZmUda857GKGPgneo0xw+M7O5Tg/Z1WbfPPc+C5ncUpj1sHz5LUaU6uSyAO48f4CdpK3dn6UjErRUM=",
+	}
+	data := "super secret access codes"
+	aad := "seq1"
+
+	ciphertext, err := LocalEncrypt(data, keyPair, aad)
+	require.NoError(t, err)
+
+	decoded, err := Decode(ciphertext)
+	require.NoError(t, err)
+
+	plaintext, err := LocalDecrypt(decoded, DataKey{Id: keyPair.Id, Key: keyPair.DataKey}, "seq2")
+	require.EqualError(t, err, "cipher: message authentication failed")
+	require.Equal(t, "", plaintext)
+
+	plaintext, err = LocalDecrypt(decoded, DataKey{Id: keyPair.Id, Key: keyPair.DataKey}, aad)
 	require.NoError(t, err)
 	require.Equal(t, data, plaintext)
 }

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -97,7 +97,7 @@ func Encrypt(
 		return "", err
 	}
 
-	return LocalEncrypt(opts.Data, dataKeyPair)
+	return LocalEncrypt(opts.Data, dataKeyPair, opts.AssociatedData)
 }
 
 // Decrypt perfroms a local decryption of data that was previously encrypted with Vault.
@@ -116,5 +116,5 @@ func Decrypt(
 		return "", err
 	}
 
-	return LocalDecrypt(decoded, dataKey)
+	return LocalDecrypt(decoded, dataKey, opts.AssociatedData)
 }


### PR DESCRIPTION
## Description

Add an optional parameter to the Vault local encrypt/decrypt functions for additionally authenticated data.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
https://github.com/workos/workos/pull/38690
