### PR TITLE
Add "warnings" field to FGA query and check response

### DIFF
--- a/pkg/fga/client.go
+++ b/pkg/fga/client.go
@@ -380,21 +380,23 @@ type CheckBatchOpts struct {
 }
 
 type Warning interface {
-	Message() string
-	Code() string
+	Warning() string
 }
 
 type BaseWarning struct {
-	C   string `json:"code"`
-	Msg string `json:"message"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
-func (b BaseWarning) Code() string    { return b.C }
-func (b BaseWarning) Message() string { return b.Msg }
+func (b BaseWarning) Warning() string { return fmt.Sprintf("%s: %s", b.Code, b.Message) }
 
 type MissingContextKeysWarning struct {
 	BaseWarning
 	Keys []string `json:"keys"`
+}
+
+func (m MissingContextKeysWarning) Warning() string {
+	return fmt.Sprintf("%s: %s [%s]", m.Code, m.Message, strings.Join(m.Keys, ", "))
 }
 
 type ConvertSchemaWarning struct {

--- a/pkg/fga/client.go
+++ b/pkg/fga/client.go
@@ -380,7 +380,7 @@ type CheckBatchOpts struct {
 }
 
 type Warning interface {
-	GetWarning() string
+	GetMessage() string
 	GetCode() string
 }
 
@@ -389,7 +389,7 @@ type BaseWarning struct {
 	Message string `json:"message"`
 }
 
-func (b BaseWarning) GetWarning() string {
+func (b BaseWarning) GetMessage() string {
 	return b.Message
 }
 

--- a/pkg/fga/client_test.go
+++ b/pkg/fga/client_test.go
@@ -1114,21 +1114,21 @@ func checkTestHandlerWarnings(w http.ResponseWriter, r *http.Request) {
 	warnings := []Warning{
 		&MissingContextKeysWarning{
 			BaseWarning: BaseWarning{
-				C:   "missing_context_keys",
-				Msg: "Some context keys were not provided.",
+				Code:    "missing_context_keys",
+				Message: "Some context keys were not provided.",
 			},
 			Keys: []string{"user_id", "org_id"},
 		},
 
 		&BaseWarning{
-			C:   "unknown",
-			Msg: "Unknown warning occurred.",
+			Code:    "unknown",
+			Message: "Unknown warning occurred.",
 		},
 
 		&ConvertSchemaWarning{
 			BaseWarning: BaseWarning{
-				C:   "validation_warning",
-				Msg: "Schema validation produced a warning.",
+				Code:    "validation_warning",
+				Message: "Schema validation produced a warning.",
 			},
 		},
 	}
@@ -1384,19 +1384,19 @@ func queryTestHandlerWarnings(w http.ResponseWriter, r *http.Request) {
 	warnings := []Warning{
 		&MissingContextKeysWarning{
 			BaseWarning: BaseWarning{
-				C:   "missing_context_keys",
-				Msg: "Some context keys were not provided.",
+				Code:    "missing_context_keys",
+				Message: "Some context keys were not provided.",
 			},
 			Keys: []string{"user_id", "org_id"},
 		},
 		&BaseWarning{
-			C:   "unknown",
-			Msg: "Unknown warning occurred.",
+			Code:    "unknown",
+			Message: "Unknown warning occurred.",
 		},
 		&ConvertSchemaWarning{
 			BaseWarning: BaseWarning{
-				C:   "validation_warning",
-				Msg: "Schema validation produced a warning.",
+				Code:    "validation_warning",
+				Message: "Schema validation produced a warning.",
 			},
 		},
 	}

--- a/pkg/fga/client_test.go
+++ b/pkg/fga/client_test.go
@@ -1111,28 +1111,24 @@ func checkTestHandlerWarnings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create concrete warnings and wrap them
-	warnings := []WarningWrapper{
-		{
-			Warning: &MissingContextKeysWarning{
-				BaseWarning: BaseWarning{
-					Code:    "missing_context_keys",
-					Message: "Some context keys were not provided.",
-				},
-				Keys: []string{"user_id", "org_id"},
+	warnings := []Warning{
+		&MissingContextKeysWarning{
+			BaseWarning: BaseWarning{
+				C:   "missing_context_keys",
+				Msg: "Some context keys were not provided.",
 			},
+			Keys: []string{"user_id", "org_id"},
 		},
-		{
-			Warning: &BaseWarning{
-				Code:    "unknown",
-				Message: "Unknown warning occurred.",
-			},
+
+		&BaseWarning{
+			C:   "unknown",
+			Msg: "Unknown warning occurred.",
 		},
-		{
-			Warning: &ConvertSchemaWarning{
-				BaseWarning: BaseWarning{
-					Code:    "validation_warning",
-					Message: "Schema validation produced a warning.",
-				},
+
+		&ConvertSchemaWarning{
+			BaseWarning: BaseWarning{
+				C:   "validation_warning",
+				Msg: "Schema validation produced a warning.",
 			},
 		},
 	}
@@ -1385,28 +1381,22 @@ func queryTestHandlerWarnings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create concrete warnings and wrap them
-	warnings := []WarningWrapper{
-		{
-			Warning: &MissingContextKeysWarning{
-				BaseWarning: BaseWarning{
-					Code:    "missing_context_keys",
-					Message: "Some context keys were not provided.",
-				},
-				Keys: []string{"user_id", "org_id"},
+	warnings := []Warning{
+		&MissingContextKeysWarning{
+			BaseWarning: BaseWarning{
+				C:   "missing_context_keys",
+				Msg: "Some context keys were not provided.",
 			},
+			Keys: []string{"user_id", "org_id"},
 		},
-		{
-			Warning: &BaseWarning{
-				Code:    "unknown",
-				Message: "Unknown warning occurred.",
-			},
+		&BaseWarning{
+			C:   "unknown",
+			Msg: "Unknown warning occurred.",
 		},
-		{
-			Warning: &ConvertSchemaWarning{
-				BaseWarning: BaseWarning{
-					Code:    "validation_warning",
-					Message: "Schema validation produced a warning.",
-				},
+		&ConvertSchemaWarning{
+			BaseWarning: BaseWarning{
+				C:   "validation_warning",
+				Msg: "Schema validation produced a warning.",
 			},
 		},
 	}

--- a/pkg/fga/fga_test.go
+++ b/pkg/fga/fga_test.go
@@ -400,12 +400,12 @@ func TestFGACheckWithWarnings(t *testing.T) {
 	require.Len(t, checkResponse.Warnings, 3)
 
 	sort.Slice(checkResponse.Warnings, func(i, j int) bool {
-		return checkResponse.Warnings[i].Warning.GetCode() < checkResponse.Warnings[j].Warning.GetCode()
+		return checkResponse.Warnings[i].Code() < checkResponse.Warnings[j].Code()
 	})
 
-	first := checkResponse.Warnings[0].Warning
-	second := checkResponse.Warnings[1].Warning
-	third := checkResponse.Warnings[2].Warning
+	first := checkResponse.Warnings[0]
+	second := checkResponse.Warnings[1]
+	third := checkResponse.Warnings[2]
 
 	mw, ok := first.(*MissingContextKeysWarning)
 	require.True(t, ok)
@@ -413,11 +413,11 @@ func TestFGACheckWithWarnings(t *testing.T) {
 
 	bw, ok := second.(*BaseWarning)
 	require.True(t, ok)
-	require.Equal(t, "unknown", bw.Code)
+	require.Equal(t, "unknown", bw.Code())
 
 	cw, ok := third.(*ConvertSchemaWarning)
 	require.True(t, ok)
-	require.Equal(t, "validation_warning", cw.Code)
+	require.Equal(t, "validation_warning", cw.Code())
 }
 
 func TestFGACheckBatch(t *testing.T) {
@@ -508,12 +508,12 @@ func TestFGAQueryWithWarnings(t *testing.T) {
 	require.Len(t, queryResponse.Warnings, 3)
 
 	sort.Slice(queryResponse.Warnings, func(i, j int) bool {
-		return queryResponse.Warnings[i].Warning.GetCode() < queryResponse.Warnings[j].Warning.GetCode()
+		return queryResponse.Warnings[i].Code() < queryResponse.Warnings[j].Code()
 	})
 
-	first := queryResponse.Warnings[0].Warning
-	second := queryResponse.Warnings[1].Warning
-	third := queryResponse.Warnings[2].Warning
+	first := queryResponse.Warnings[0]
+	second := queryResponse.Warnings[1]
+	third := queryResponse.Warnings[2]
 
 	mw, ok := first.(*MissingContextKeysWarning)
 	require.True(t, ok)
@@ -521,11 +521,11 @@ func TestFGAQueryWithWarnings(t *testing.T) {
 
 	bw, ok := second.(*BaseWarning)
 	require.True(t, ok)
-	require.Equal(t, "unknown", bw.Code)
+	require.Equal(t, "unknown", bw.Code())
 
 	cw, ok := third.(*ConvertSchemaWarning)
 	require.True(t, ok)
-	require.Equal(t, "validation_warning", cw.Code)
+	require.Equal(t, "validation_warning", cw.Code())
 }
 
 func TestFGAConvertSchemaToResourceTypes(t *testing.T) {

--- a/pkg/fga/fga_test.go
+++ b/pkg/fga/fga_test.go
@@ -400,7 +400,7 @@ func TestFGACheckWithWarnings(t *testing.T) {
 	require.Len(t, checkResponse.Warnings, 3)
 
 	sort.Slice(checkResponse.Warnings, func(i, j int) bool {
-		return checkResponse.Warnings[i].Code() < checkResponse.Warnings[j].Code()
+		return checkResponse.Warnings[i].Warning() < checkResponse.Warnings[j].Warning()
 	})
 
 	first := checkResponse.Warnings[0]
@@ -413,11 +413,11 @@ func TestFGACheckWithWarnings(t *testing.T) {
 
 	bw, ok := second.(*BaseWarning)
 	require.True(t, ok)
-	require.Equal(t, "unknown", bw.Code())
+	require.Equal(t, "unknown", bw.Code)
 
 	cw, ok := third.(*ConvertSchemaWarning)
 	require.True(t, ok)
-	require.Equal(t, "validation_warning", cw.Code())
+	require.Equal(t, "validation_warning", cw.Code)
 }
 
 func TestFGACheckBatch(t *testing.T) {
@@ -508,7 +508,7 @@ func TestFGAQueryWithWarnings(t *testing.T) {
 	require.Len(t, queryResponse.Warnings, 3)
 
 	sort.Slice(queryResponse.Warnings, func(i, j int) bool {
-		return queryResponse.Warnings[i].Code() < queryResponse.Warnings[j].Code()
+		return queryResponse.Warnings[i].Warning() < queryResponse.Warnings[j].Warning()
 	})
 
 	first := queryResponse.Warnings[0]
@@ -521,11 +521,11 @@ func TestFGAQueryWithWarnings(t *testing.T) {
 
 	bw, ok := second.(*BaseWarning)
 	require.True(t, ok)
-	require.Equal(t, "unknown", bw.Code())
+	require.Equal(t, "unknown", bw.Code)
 
 	cw, ok := third.(*ConvertSchemaWarning)
 	require.True(t, ok)
-	require.Equal(t, "validation_warning", cw.Code())
+	require.Equal(t, "validation_warning", cw.Code)
 }
 
 func TestFGAConvertSchemaToResourceTypes(t *testing.T) {

--- a/pkg/fga/fga_test.go
+++ b/pkg/fga/fga_test.go
@@ -2,7 +2,6 @@ package fga
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -412,7 +411,6 @@ func TestFGACheckWithWarnings(t *testing.T) {
 	require.True(t, ok)
 	require.ElementsMatch(t, mw.Keys, []string{"user_id", "org_id"})
 
-	fmt.Println(second)
 	bw, ok := second.(*BaseWarning)
 	require.True(t, ok)
 	require.Equal(t, "unknown", bw.Code)


### PR DESCRIPTION
## Description
Adds `warnings` field to the FGA check and query responses. `Warnings` is a slice of `WarningWrapper` that contain a specific warning type. Warning types include:

- `BaseWarning` - catch all for warnings not supported by the current SDK version
- `MissingContextKeysWarning` - missing context keys found while evaluating policies in the check / query request 
- `ConvertSchemaWarning` - validation failed for schema [not used with check / query]
