### PR TITLE
added `omitempty` to ExternalID field

### DIFF
--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -187,7 +187,7 @@ type CreateOrganizationOpts struct {
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
 
 	// The Organization's external id.
-	ExternalID string `json:"external_id"`
+	ExternalID string `json:"external_id,omitempty"`
 
 	// The Organization's metadata.
 	Metadata map[string]string `json:"metadata"`


### PR DESCRIPTION
## Description

`ExternalID` was added to the organization struct in `v4.37.0` and it was causing validation errors for users who weren't passing an empty string. This PR adds `omitempty` to the field so that empty values for this field are ignored and validation errors don't pop up. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
