### PR TITLE
bump to v4.41.0

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.40.0"
+	Version = "v4.41.0"
 )


### PR DESCRIPTION
## Description
version bump that includes:
- https://github.com/workos/workos-go/pull/431

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
