### PR TITLE
Correctly deserialize `ListIdentitiesResult` as array

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -600,9 +600,7 @@ type RevokeSessionOpts struct {
 	SessionID string `json:"session_id"`
 }
 
-type ListIdentitiesResult struct {
-	Identities []Identity `json:"identities"`
-}
+type ListIdentitiesResult = []Identity
 
 type ListIdentitiesOpts struct {
 	ID string `json:"id"`

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -612,12 +612,10 @@ func TestListIdentities(t *testing.T) {
 				ID: "user_01E3JC5F5Z1YJNPGVYWV9SX6GH",
 			},
 			expected: ListIdentitiesResult{
-				Identities: []Identity{
-					{
-						IdpID:    "13966412",
-						Type:     "OAuth",
-						Provider: "GitHubOAuth",
-					},
+				{
+					IdpID:    "13966412",
+					Type:     "OAuth",
+					Provider: "GitHubOAuth",
 				},
 			},
 			err: false,
@@ -661,12 +659,10 @@ func listIdentitiesTestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body, err := json.Marshal(ListIdentitiesResult{
-		Identities: []Identity{
-			{
-				IdpID:    "13966412",
-				Type:     "OAuth",
-				Provider: "GitHubOAuth",
-			},
+		{
+			IdpID:    "13966412",
+			Type:     "OAuth",
+			Provider: "GitHubOAuth",
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Description

When trying to use the `usermanagement.ListIdentities` function, the result is always an error. I believe this is because the response is just an array of `Identity` instead of an object containing the `identities` field.

## Documentation

I don't believe this needs docs update because the examples in the List Identities section don't contain a Go example.
