### PR TITLE
Update metadata serialization for updating organizations

### DIFF
--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -426,9 +426,12 @@ func (c *Client) UpdateOrganization(ctx context.Context, opts UpdateOrganization
 		//
 		// Deprecated:  Use DomainData instead.
 		Domains []string `json:"domains,omitempty"`
+
+		// The Organization's metadata.
+		Metadata map[string]string `json:"metadata,omitempty"`
 	}
 
-	update_opts := UpdateOrganizationChangeOpts{opts.Name, opts.AllowProfilesOutsideOrganization, opts.DomainData, opts.Domains}
+	update_opts := UpdateOrganizationChangeOpts{opts.Name, opts.AllowProfilesOutsideOrganization, opts.DomainData, opts.Domains, opts.Metadata}
 
 	data, err := c.JSONEncode(update_opts)
 	if err != nil {

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -431,9 +431,9 @@ func (c *Client) UpdateOrganization(ctx context.Context, opts UpdateOrganization
 		Metadata map[string]string `json:"metadata,omitempty"`
 	}
 
-	update_opts := UpdateOrganizationChangeOpts{opts.Name, opts.AllowProfilesOutsideOrganization, opts.DomainData, opts.Domains, opts.Metadata}
+	updateOpts := UpdateOrganizationChangeOpts{opts.Name, opts.AllowProfilesOutsideOrganization, opts.DomainData, opts.Domains, opts.Metadata}
 
-	data, err := c.JSONEncode(update_opts)
+	data, err := c.JSONEncode(updateOpts)
 	if err != nil {
 		return Organization{}, err
 	}

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -410,30 +410,7 @@ func (c *Client) CreateOrganization(ctx context.Context, opts CreateOrganization
 func (c *Client) UpdateOrganization(ctx context.Context, opts UpdateOrganizationOpts) (Organization, error) {
 	c.once.Do(c.init)
 
-	// UpdateOrganizationChangeOpts contains the options to update an Organization minus the org ID
-	type UpdateOrganizationChangeOpts struct {
-		// Name of the Organization.
-		Name string `json:"name"`
-
-		// Whether Connections within the Organization allow profiles that are
-		// outside of the Organization's configured User Email Domains.
-		AllowProfilesOutsideOrganization bool `json:"allow_profiles_outside_organization"`
-
-		// Domains of the Organization.
-		DomainData []OrganizationDomainData `json:"domain_data,omitempty"`
-
-		// Domains of the Organization.
-		//
-		// Deprecated:  Use DomainData instead.
-		Domains []string `json:"domains,omitempty"`
-
-		// The Organization's metadata.
-		Metadata map[string]string `json:"metadata,omitempty"`
-	}
-
-	updateOpts := UpdateOrganizationChangeOpts{opts.Name, opts.AllowProfilesOutsideOrganization, opts.DomainData, opts.Domains, opts.Metadata}
-
-	data, err := c.JSONEncode(updateOpts)
+	data, err := c.JSONEncode(opts)
 	if err != nil {
 		return Organization{}, err
 	}


### PR DESCRIPTION
## Description
Update metadata serialization for updating organizations. Coreweave flagged that this was broken and not in line with the update user metadata serialization. 

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
