### PR TITLE
Add structured authentication error handling

### DIFF
--- a/pkg/workos_errors/authentication_errors.go
+++ b/pkg/workos_errors/authentication_errors.go
@@ -1,0 +1,204 @@
+package workos_errors
+
+import (
+	"errors"
+)
+
+// Authentication error code constants
+const (
+	EmailVerificationRequiredCode                 = "email_verification_required"
+	MFAEnrollmentCode                             = "mfa_enrollment"
+	MFAChallengeCode                              = "mfa_challenge"
+	OrganizationSelectionRequiredCode             = "organization_selection_required"
+	SSORequiredCode                               = "sso_required"
+	OrganizationAuthenticationMethodsRequiredCode = "organization_authentication_methods_required"
+)
+
+// AuthenticationFactor represents an MFA factor
+type AuthenticationFactor struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+// Organization represents an organization in selection error
+type Organization struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// User represents a user in authentication errors
+type User struct {
+	Object            string `json:"object"`
+	ID                string `json:"id"`
+	Email             string `json:"email"`
+	FirstName         string `json:"first_name"`
+	LastName          string `json:"last_name"`
+	EmailVerified     bool   `json:"email_verified"`
+	ProfilePictureURL string `json:"profile_picture_url"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+}
+
+// EmailVerificationRequiredError occurs when a user with unverified email attempts authentication
+type EmailVerificationRequiredError struct {
+	HTTPError
+	Code                       string `json:"code"`
+	Message                    string `json:"message"`
+	Email                      string `json:"email"`
+	EmailVerificationID        string `json:"email_verification_id"`
+	PendingAuthenticationToken string `json:"pending_authentication_token"`
+}
+
+func (e EmailVerificationRequiredError) Error() string {
+	return e.HTTPError.Error()
+}
+
+// MFAEnrollmentError occurs when a user needs to enroll in MFA
+type MFAEnrollmentError struct {
+	HTTPError
+	Code                       string `json:"code"`
+	Message                    string `json:"message"`
+	User                       User   `json:"user"`
+	PendingAuthenticationToken string `json:"pending_authentication_token"`
+}
+
+func (e MFAEnrollmentError) Error() string {
+	return e.HTTPError.Error()
+}
+
+// MFAChallengeError occurs when a user needs to complete MFA challenge
+type MFAChallengeError struct {
+	HTTPError
+	Code                       string                 `json:"code"`
+	Message                    string                 `json:"message"`
+	User                       User                   `json:"user"`
+	AuthenticationFactors      []AuthenticationFactor `json:"authentication_factors"`
+	PendingAuthenticationToken string                 `json:"pending_authentication_token"`
+}
+
+func (e MFAChallengeError) Error() string {
+	return e.HTTPError.Error()
+}
+
+// OrganizationSelectionRequiredError occurs when user must choose an organization
+type OrganizationSelectionRequiredError struct {
+	HTTPError
+	Code                       string         `json:"code"`
+	Message                    string         `json:"message"`
+	User                       User           `json:"user"`
+	Organizations              []Organization `json:"organizations"`
+	PendingAuthenticationToken string         `json:"pending_authentication_token"`
+}
+
+func (e OrganizationSelectionRequiredError) Error() string {
+	return e.HTTPError.Error()
+}
+
+// SSORequiredError occurs when user must authenticate via SSO
+type SSORequiredError struct {
+	HTTPError
+	ErrorCode                  string   `json:"error"`
+	ErrorDescription           string   `json:"error_description"`
+	Email                      string   `json:"email"`
+	ConnectionIDs              []string `json:"connection_ids"`
+	PendingAuthenticationToken string   `json:"pending_authentication_token"`
+}
+
+func (e SSORequiredError) Error() string {
+	return e.HTTPError.Error()
+}
+
+// OrganizationAuthenticationMethodsRequiredError occurs when org restricts auth methods
+type OrganizationAuthenticationMethodsRequiredError struct {
+	HTTPError
+	ErrorCode                  string          `json:"error"`
+	ErrorDescription           string          `json:"error_description"`
+	Email                      string          `json:"email"`
+	SSOConnectionIDs           []string        `json:"sso_connection_ids"`
+	AuthMethods                map[string]bool `json:"auth_methods"`
+	PendingAuthenticationToken string          `json:"pending_authentication_token"`
+}
+
+func (e OrganizationAuthenticationMethodsRequiredError) Error() string {
+	return e.HTTPError.Error()
+}
+
+// Type checking functions
+func IsEmailVerificationRequired(err error) bool {
+	var emailErr *EmailVerificationRequiredError
+	return errors.As(err, &emailErr)
+}
+
+func IsMFAEnrollment(err error) bool {
+	var mfaErr *MFAEnrollmentError
+	return errors.As(err, &mfaErr)
+}
+
+func IsMFAChallenge(err error) bool {
+	var mfaErr *MFAChallengeError
+	return errors.As(err, &mfaErr)
+}
+
+func IsOrganizationSelectionRequired(err error) bool {
+	var orgErr *OrganizationSelectionRequiredError
+	return errors.As(err, &orgErr)
+}
+
+func IsSSORequired(err error) bool {
+	var ssoErr *SSORequiredError
+	return errors.As(err, &ssoErr)
+}
+
+func IsOrganizationAuthenticationMethodsRequired(err error) bool {
+	var orgAuthErr *OrganizationAuthenticationMethodsRequiredError
+	return errors.As(err, &orgAuthErr)
+}
+
+// Type assertion functions
+func AsEmailVerificationRequired(err error) (*EmailVerificationRequiredError, bool) {
+	var emailErr *EmailVerificationRequiredError
+	if errors.As(err, &emailErr) {
+		return emailErr, true
+	}
+	return nil, false
+}
+
+func AsMFAEnrollment(err error) (*MFAEnrollmentError, bool) {
+	var mfaErr *MFAEnrollmentError
+	if errors.As(err, &mfaErr) {
+		return mfaErr, true
+	}
+	return nil, false
+}
+
+func AsMFAChallenge(err error) (*MFAChallengeError, bool) {
+	var mfaErr *MFAChallengeError
+	if errors.As(err, &mfaErr) {
+		return mfaErr, true
+	}
+	return nil, false
+}
+
+func AsOrganizationSelectionRequired(err error) (*OrganizationSelectionRequiredError, bool) {
+	var orgErr *OrganizationSelectionRequiredError
+	if errors.As(err, &orgErr) {
+		return orgErr, true
+	}
+	return nil, false
+}
+
+func AsSSORequired(err error) (*SSORequiredError, bool) {
+	var ssoErr *SSORequiredError
+	if errors.As(err, &ssoErr) {
+		return ssoErr, true
+	}
+	return nil, false
+}
+
+func AsOrganizationAuthenticationMethodsRequired(err error) (*OrganizationAuthenticationMethodsRequiredError, bool) {
+	var orgAuthErr *OrganizationAuthenticationMethodsRequiredError
+	if errors.As(err, &orgAuthErr) {
+		return orgAuthErr, true
+	}
+	return nil, false
+}

--- a/pkg/workos_errors/authentication_errors_test.go
+++ b/pkg/workos_errors/authentication_errors_test.go
@@ -1,0 +1,343 @@
+package workos_errors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmailVerificationRequiredError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-ID", "test-request-id")
+	rec.Header().Set("Content-Type", "application/json")
+	rec.WriteHeader(http.StatusUnprocessableEntity)
+	rec.WriteString(`{
+		"code": "email_verification_required",
+		"message": "Email ownership must be verified before authentication.",
+		"pending_authentication_token": "YQyCkYfuVw2mI3tzSrk2C1Y7S",
+		"email": "marcelina.davis@example.com",
+		"email_verification_id": "email_verification_01HYGGEB6FYMWQNWF3XDZG7VV3"
+	}`)
+
+	err := TryGetHTTPError(rec.Result())
+	require.Error(t, err)
+
+	// Test type checking
+	require.True(t, IsEmailVerificationRequired(err))
+
+	// Test type assertion
+	emailErr, ok := AsEmailVerificationRequired(err)
+	require.True(t, ok)
+	require.NotNil(t, emailErr)
+	require.Equal(t, "email_verification_required", emailErr.ErrorCode)
+	require.Equal(t, "email_verification_required", emailErr.Code)
+	require.Equal(t, "Email ownership must be verified before authentication.", emailErr.Message)
+	require.Equal(t, "marcelina.davis@example.com", emailErr.Email)
+	require.Equal(t, "email_verification_01HYGGEB6FYMWQNWF3XDZG7VV3", emailErr.EmailVerificationID)
+	require.Equal(t, "YQyCkYfuVw2mI3tzSrk2C1Y7S", emailErr.PendingAuthenticationToken)
+	require.Equal(t, "test-request-id", emailErr.RequestID)
+}
+
+func TestMFAEnrollmentError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-ID", "test-request-id")
+	rec.Header().Set("Content-Type", "application/json")
+	rec.WriteHeader(http.StatusUnprocessableEntity)
+	rec.WriteString(`{
+		"code": "mfa_enrollment",
+		"message": "The user must enroll in MFA to finish authenticating.",
+		"pending_authentication_token": "YQyCkYfuVw2mI3tzSrk2C1Y7S",
+		"user": {
+			"object": "user",
+			"id": "user_01E4ZCR3C56J083X43JQXF3JK5",
+			"email": "marcelina.davis@example.com",
+			"first_name": "Marcelina",
+			"last_name": "Davis",
+			"email_verified": true,
+			"profile_picture_url": "https://workoscdn.com/images/v1/123abc",
+			"created_at": "2021-06-25T19:07:33.155Z",
+			"updated_at": "2021-06-25T19:07:33.155Z"
+		}
+	}`)
+
+	err := TryGetHTTPError(rec.Result())
+	require.Error(t, err)
+
+	// Test type checking
+	require.True(t, IsMFAEnrollment(err))
+
+	// Test type assertion
+	mfaErr, ok := AsMFAEnrollment(err)
+	require.True(t, ok)
+	require.NotNil(t, mfaErr)
+	require.Equal(t, "mfa_enrollment", mfaErr.ErrorCode)
+	require.Equal(t, "user_01E4ZCR3C56J083X43JQXF3JK5", mfaErr.User.ID)
+	require.Equal(t, "marcelina.davis@example.com", mfaErr.User.Email)
+	require.Equal(t, "Marcelina", mfaErr.User.FirstName)
+	require.Equal(t, "Davis", mfaErr.User.LastName)
+	require.True(t, mfaErr.User.EmailVerified)
+	require.Equal(t, "YQyCkYfuVw2mI3tzSrk2C1Y7S", mfaErr.PendingAuthenticationToken)
+}
+
+func TestMFAChallengeError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-ID", "test-request-id")
+	rec.Header().Set("Content-Type", "application/json")
+	rec.WriteHeader(http.StatusUnprocessableEntity)
+	rec.WriteString(`{
+		"code": "mfa_challenge",
+		"message": "The user must complete an MFA challenge to finish authenticating.",
+		"pending_authentication_token": "YQyCkYfuVw2mI3tzSrk2C1Y7S",
+		"authentication_factors": [
+			{
+				"id": "auth_factor_01FVYZ5QM8N98T9ME5BCB2BBMJ",
+				"type": "totp"
+			}
+		],
+		"user": {
+			"object": "user",
+			"id": "user_01E4ZCR3C56J083X43JQXF3JK5",
+			"email": "marcelina.davis@example.com",
+			"first_name": "Marcelina",
+			"last_name": "Davis",
+			"email_verified": true,
+			"profile_picture_url": "https://workoscdn.com/images/v1/123abc",
+			"created_at": "2021-06-25T19:07:33.155Z",
+			"updated_at": "2021-06-25T19:07:33.155Z"
+		}
+	}`)
+
+	err := TryGetHTTPError(rec.Result())
+	require.Error(t, err)
+
+	// Test type checking
+	require.True(t, IsMFAChallenge(err))
+
+	// Test type assertion
+	mfaErr, ok := AsMFAChallenge(err)
+	require.True(t, ok)
+	require.NotNil(t, mfaErr)
+	require.Equal(t, "mfa_challenge", mfaErr.ErrorCode)
+	require.Equal(t, "user_01E4ZCR3C56J083X43JQXF3JK5", mfaErr.User.ID)
+	require.Equal(t, "marcelina.davis@example.com", mfaErr.User.Email)
+	require.Len(t, mfaErr.AuthenticationFactors, 1)
+	require.Equal(t, "auth_factor_01FVYZ5QM8N98T9ME5BCB2BBMJ", mfaErr.AuthenticationFactors[0].ID)
+	require.Equal(t, "totp", mfaErr.AuthenticationFactors[0].Type)
+	require.Equal(t, "YQyCkYfuVw2mI3tzSrk2C1Y7S", mfaErr.PendingAuthenticationToken)
+}
+
+func TestOrganizationSelectionRequiredError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-ID", "test-request-id")
+	rec.Header().Set("Content-Type", "application/json")
+	rec.WriteHeader(http.StatusUnprocessableEntity)
+	rec.WriteString(`{
+		"code": "organization_selection_required",
+		"message": "The user must choose an organization to finish their authentication.",
+		"pending_authentication_token": "YQyCkYfuVw2mI3tzSrk2C1Y7S",
+		"organizations": [
+			{
+				"id": "org_01H93RZAP85YGYZJXYPAZ9QTXF",
+				"name": "Foo Corp"
+			},
+			{
+				"id": "org_01H93S4E6GB5A8PFNKGTA4S42X",
+				"name": "Bar Corp"
+			}
+		],
+		"user": {
+			"object": "user",
+			"id": "user_01E4ZCR3C56J083X43JQXF3JK5",
+			"email": "marcelina.davis@example.com",
+			"first_name": "Marcelina",
+			"last_name": "Davis",
+			"email_verified": true,
+			"profile_picture_url": "https://workoscdn.com/images/v1/123abc",
+			"created_at": "2021-06-25T19:07:33.155Z",
+			"updated_at": "2021-06-25T19:07:33.155Z"
+		}
+	}`)
+
+	err := TryGetHTTPError(rec.Result())
+	require.Error(t, err)
+
+	// Test type checking
+	require.True(t, IsOrganizationSelectionRequired(err))
+
+	// Test type assertion
+	orgErr, ok := AsOrganizationSelectionRequired(err)
+	require.True(t, ok)
+	require.NotNil(t, orgErr)
+	require.Equal(t, "organization_selection_required", orgErr.ErrorCode)
+	require.Equal(t, "user_01E4ZCR3C56J083X43JQXF3JK5", orgErr.User.ID)
+	require.Equal(t, "marcelina.davis@example.com", orgErr.User.Email)
+	require.Len(t, orgErr.Organizations, 2)
+	require.Equal(t, "org_01H93RZAP85YGYZJXYPAZ9QTXF", orgErr.Organizations[0].ID)
+	require.Equal(t, "Foo Corp", orgErr.Organizations[0].Name)
+	require.Equal(t, "org_01H93S4E6GB5A8PFNKGTA4S42X", orgErr.Organizations[1].ID)
+	require.Equal(t, "Bar Corp", orgErr.Organizations[1].Name)
+	require.Equal(t, "YQyCkYfuVw2mI3tzSrk2C1Y7S", orgErr.PendingAuthenticationToken)
+}
+
+func TestSSORequiredError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-ID", "test-request-id")
+	rec.Header().Set("Content-Type", "application/json")
+	rec.WriteHeader(http.StatusUnprocessableEntity)
+	rec.WriteString(`{
+		"error": "sso_required",
+		"error_description": "User must authenticate using one of the matching connections.",
+		"connection_ids": ["conn_01DRF1T7JN6GXS8KHS0WYWX1YD"],
+		"email": "marcelina.davis@example.com",
+		"pending_authentication_token": "YQyCkYfuVw2mI3tzSrk2C1Y7S"
+	}`)
+
+	err := TryGetHTTPError(rec.Result())
+	require.Error(t, err)
+
+	// Test type checking
+	require.True(t, IsSSORequired(err))
+
+	// Test type assertion
+	ssoErr, ok := AsSSORequired(err)
+	require.True(t, ok)
+	require.NotNil(t, ssoErr)
+	require.Equal(t, "sso_required", ssoErr.ErrorCode)
+	require.Equal(t, "marcelina.davis@example.com", ssoErr.Email)
+	require.Len(t, ssoErr.ConnectionIDs, 1)
+	require.Equal(t, "conn_01DRF1T7JN6GXS8KHS0WYWX1YD", ssoErr.ConnectionIDs[0])
+	require.Equal(t, "YQyCkYfuVw2mI3tzSrk2C1Y7S", ssoErr.PendingAuthenticationToken)
+}
+
+func TestOrganizationAuthenticationMethodsRequiredError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-ID", "test-request-id")
+	rec.Header().Set("Content-Type", "application/json")
+	rec.WriteHeader(http.StatusUnprocessableEntity)
+	rec.WriteString(`{
+		"error": "organization_authentication_methods_required",
+		"error_description": "User must authenticate using one of the methods allowed by the organization.",
+		"sso_connection_ids": ["conn_01DRF1T7JN6GXS8KHS0WYWX1YD"],
+		"auth_methods": {
+			"apple_oauth": false,
+			"github_oauth": false,
+			"google_oauth": true,
+			"magic_auth": false,
+			"microsoft_oauth": false,
+			"password": false
+		},
+		"email": "marcelina.davis@example.com",
+		"pending_authentication_token": "YQyCkYfuVw2mI3tzSrk2C1Y7S"
+	}`)
+
+	err := TryGetHTTPError(rec.Result())
+	require.Error(t, err)
+
+	// Test type checking
+	require.True(t, IsOrganizationAuthenticationMethodsRequired(err))
+
+	// Test type assertion
+	orgAuthErr, ok := AsOrganizationAuthenticationMethodsRequired(err)
+	require.True(t, ok)
+	require.NotNil(t, orgAuthErr)
+	require.Equal(t, "organization_authentication_methods_required", orgAuthErr.ErrorCode)
+	require.Equal(t, "marcelina.davis@example.com", orgAuthErr.Email)
+	require.Len(t, orgAuthErr.SSOConnectionIDs, 1)
+	require.Equal(t, "conn_01DRF1T7JN6GXS8KHS0WYWX1YD", orgAuthErr.SSOConnectionIDs[0])
+	require.Len(t, orgAuthErr.AuthMethods, 6)
+	require.False(t, orgAuthErr.AuthMethods["apple_oauth"])
+	require.False(t, orgAuthErr.AuthMethods["github_oauth"])
+	require.True(t, orgAuthErr.AuthMethods["google_oauth"])
+	require.False(t, orgAuthErr.AuthMethods["magic_auth"])
+	require.False(t, orgAuthErr.AuthMethods["microsoft_oauth"])
+	require.False(t, orgAuthErr.AuthMethods["password"])
+	require.Equal(t, "YQyCkYfuVw2mI3tzSrk2C1Y7S", orgAuthErr.PendingAuthenticationToken)
+}
+
+func TestNonAuthenticationErrorFallsBackToGeneric(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-ID", "test-request-id")
+	rec.Header().Set("Content-Type", "application/json")
+	rec.WriteHeader(http.StatusBadRequest)
+	rec.WriteString(`{
+		"message": "Invalid request",
+		"code": "invalid_request"
+	}`)
+
+	err := TryGetHTTPError(rec.Result())
+	require.Error(t, err)
+
+	// Should not be any of the authentication error types
+	require.False(t, IsEmailVerificationRequired(err))
+	require.False(t, IsMFAEnrollment(err))
+	require.False(t, IsMFAChallenge(err))
+	require.False(t, IsOrganizationSelectionRequired(err))
+	require.False(t, IsSSORequired(err))
+	require.False(t, IsOrganizationAuthenticationMethodsRequired(err))
+
+	// Should be a generic HTTPError
+	httpErr, ok := err.(HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, httpErr.Code)
+	require.Equal(t, "Invalid request", httpErr.Message)
+	require.Equal(t, "invalid_request", httpErr.ErrorCode)
+}
+
+func TestTypeAssertionFunctionsReturnFalseForWrongTypes(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "application/json")
+	rec.WriteHeader(http.StatusBadRequest)
+	rec.WriteString(`{
+		"message": "Invalid request",
+		"code": "invalid_request"
+	}`)
+
+	err := TryGetHTTPError(rec.Result())
+	require.Error(t, err)
+
+	// All type assertions should return false for non-authentication errors
+	_, ok := AsEmailVerificationRequired(err)
+	require.False(t, ok)
+
+	_, ok = AsMFAEnrollment(err)
+	require.False(t, ok)
+
+	_, ok = AsMFAChallenge(err)
+	require.False(t, ok)
+
+	_, ok = AsOrganizationSelectionRequired(err)
+	require.False(t, ok)
+
+	_, ok = AsSSORequired(err)
+	require.False(t, ok)
+
+	_, ok = AsOrganizationAuthenticationMethodsRequired(err)
+	require.False(t, ok)
+}
+
+func TestErrorStringFormatting(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-ID", "test-request-id")
+	rec.Header().Set("Content-Type", "application/json")
+	rec.WriteHeader(http.StatusUnprocessableEntity)
+	rec.WriteString(`{
+		"code": "email_verification_required",
+		"message": "Email ownership must be verified before authentication.",
+		"pending_authentication_token": "YQyCkYfuVw2mI3tzSrk2C1Y7S",
+		"email": "marcelina.davis@example.com",
+		"email_verification_id": "email_verification_01HYGGEB6FYMWQNWF3XDZG7VV3"
+	}`)
+
+	err := TryGetHTTPError(rec.Result())
+	require.Error(t, err)
+
+	// Test that the error message includes the expected information
+	errMsg := err.Error()
+	require.Contains(t, errMsg, "422 Unprocessable Entity")
+	require.Contains(t, errMsg, "test-request-id")
+	require.Contains(t, errMsg, "Email ownership must be verified before authentication")
+	require.Contains(t, errMsg, "pending_authentication_token: \"YQyCkYfuVw2mI3tzSrk2C1Y7S\"")
+	require.Contains(t, errMsg, "email_verification_id: \"email_verification_01HYGGEB6FYMWQNWF3XDZG7VV3\"")
+}

--- a/pkg/workos_errors/http.go
+++ b/pkg/workos_errors/http.go
@@ -16,23 +16,56 @@ func TryGetHTTPError(r *http.Response) error {
 		return nil
 	}
 
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return HTTPError{
+			Code:    r.StatusCode,
+			Status:  r.Status,
+			Message: err.Error(),
+		}
+	}
+
+	// Try to parse as authentication error first
+	if isJsonResponse(r) {
+		if authErr := parseAuthenticationError(body, r.StatusCode); authErr != nil {
+			// Set RequestID on the error
+			requestID := r.Header.Get("X-Request-ID")
+			if httpErr, ok := authErr.(*HTTPError); ok {
+				httpErr.RequestID = requestID
+			} else if httpErr, ok := authErr.(HTTPError); ok {
+				httpErr.RequestID = requestID
+				return httpErr
+			} else {
+				// For structured authentication errors, set the RequestID on the embedded HTTPError
+				switch e := authErr.(type) {
+				case *EmailVerificationRequiredError:
+					e.RequestID = requestID
+				case *MFAEnrollmentError:
+					e.RequestID = requestID
+				case *MFAChallengeError:
+					e.RequestID = requestID
+				case *OrganizationSelectionRequiredError:
+					e.RequestID = requestID
+				case *SSORequiredError:
+					e.RequestID = requestID
+				case *OrganizationAuthenticationMethodsRequiredError:
+					e.RequestID = requestID
+				}
+			}
+			return authErr
+		}
+	}
+
+	// Fall back to generic error parsing
 	var msg, code string
 	var errors []string
 	var fieldErrors []FieldError
 	var pendingAuthToken, emailVerificationID string
 
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		msg = err.Error()
+	if isJsonResponse(r) {
+		msg, code, errors, fieldErrors, pendingAuthToken, emailVerificationID = getJsonErrorMessage(body, r.StatusCode)
 	} else {
-		// Print the raw response body
-		rawBody := string(body)
-
-		if isJsonResponse(r) {
-			msg, code, errors, fieldErrors, pendingAuthToken, emailVerificationID = getJsonErrorMessage(body, r.StatusCode)
-		} else {
-			msg = rawBody
-		}
+		msg = string(body)
 	}
 
 	return HTTPError{
@@ -121,14 +154,148 @@ func getJsonErrorMessage(b []byte, statusCode int) (string, string, []string, []
 	}
 
 	if payload.Error != "" && payload.ErrorDescription != "" {
-		return fmt.Sprintf("%s %s", payload.Error, payload.ErrorDescription), "", nil, nil, payload.PendingAuthenticationToken, payload.EmailVerificationID
+		return fmt.Sprintf("%s %s", payload.Error, payload.ErrorDescription), payload.Error, nil, nil, payload.PendingAuthenticationToken, payload.EmailVerificationID
 	} else if payload.Message != "" && len(payload.Errors) == 0 {
-		return payload.Message, "", nil, nil, payload.PendingAuthenticationToken, payload.EmailVerificationID
+		return payload.Message, payload.Code, nil, nil, payload.PendingAuthenticationToken, payload.EmailVerificationID
 	} else if payload.Message != "" && len(payload.Errors) > 0 {
 		return payload.Message, payload.Code, payload.Errors, nil, payload.PendingAuthenticationToken, payload.EmailVerificationID
 	}
 
 	return string(b), "", nil, nil, "", ""
+}
+
+// parseAuthenticationError creates the appropriate structured error type based on the error code
+func parseAuthenticationError(b []byte, statusCode int) error {
+	// Try parsing with code/message format first
+	var payload struct {
+		Message                    string                 `json:"message"`
+		Code                       string                 `json:"code"`
+		PendingAuthenticationToken string                 `json:"pending_authentication_token"`
+		EmailVerificationID        string                 `json:"email_verification_id"`
+		Email                      string                 `json:"email"`
+		User                       *User                  `json:"user"`
+		AuthenticationFactors      []AuthenticationFactor `json:"authentication_factors"`
+		Organizations              []Organization         `json:"organizations"`
+		ConnectionIDs              []string               `json:"connection_ids"`
+		SSOConnectionIDs           []string               `json:"sso_connection_ids"`
+		AuthMethods                map[string]bool        `json:"auth_methods"`
+	}
+
+	if err := json.Unmarshal(b, &payload); err == nil && payload.Code != "" {
+		// Create base HTTPError
+		httpErr := HTTPError{
+			Code:                       statusCode,
+			Status:                     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+			Message:                    payload.Message,
+			ErrorCode:                  payload.Code,
+			PendingAuthenticationToken: payload.PendingAuthenticationToken,
+			EmailVerificationID:        payload.EmailVerificationID,
+			AuthenticationFactors:      payload.AuthenticationFactors,
+			Organizations:              payload.Organizations,
+			ConnectionIDs:              payload.ConnectionIDs,
+			SSOConnectionIDs:           payload.SSOConnectionIDs,
+			AuthMethods:                payload.AuthMethods,
+			User:                       payload.User,
+			RawBody:                    string(b),
+		}
+
+		// Return appropriate structured error based on code
+		switch payload.Code {
+		case EmailVerificationRequiredCode:
+			return &EmailVerificationRequiredError{
+				HTTPError:                  httpErr,
+				Code:                       payload.Code,
+				Message:                    payload.Message,
+				Email:                      payload.Email,
+				EmailVerificationID:        payload.EmailVerificationID,
+				PendingAuthenticationToken: payload.PendingAuthenticationToken,
+			}
+		case MFAEnrollmentCode:
+			if payload.User != nil {
+				return &MFAEnrollmentError{
+					HTTPError:                  httpErr,
+					Code:                       payload.Code,
+					Message:                    payload.Message,
+					User:                       *payload.User,
+					PendingAuthenticationToken: payload.PendingAuthenticationToken,
+				}
+			}
+		case MFAChallengeCode:
+			if payload.User != nil {
+				return &MFAChallengeError{
+					HTTPError:                  httpErr,
+					Code:                       payload.Code,
+					Message:                    payload.Message,
+					User:                       *payload.User,
+					AuthenticationFactors:      payload.AuthenticationFactors,
+					PendingAuthenticationToken: payload.PendingAuthenticationToken,
+				}
+			}
+		case OrganizationSelectionRequiredCode:
+			if payload.User != nil {
+				return &OrganizationSelectionRequiredError{
+					HTTPError:                  httpErr,
+					Code:                       payload.Code,
+					Message:                    payload.Message,
+					User:                       *payload.User,
+					Organizations:              payload.Organizations,
+					PendingAuthenticationToken: payload.PendingAuthenticationToken,
+				}
+			}
+		}
+	}
+
+	// Try parsing with error/error_description format for SSO and org auth methods
+	var errorPayload struct {
+		Error                      string          `json:"error"`
+		ErrorDescription           string          `json:"error_description"`
+		PendingAuthenticationToken string          `json:"pending_authentication_token"`
+		Email                      string          `json:"email"`
+		ConnectionIDs              []string        `json:"connection_ids"`
+		SSOConnectionIDs           []string        `json:"sso_connection_ids"`
+		AuthMethods                map[string]bool `json:"auth_methods"`
+	}
+
+	if err := json.Unmarshal(b, &errorPayload); err == nil && errorPayload.Error != "" {
+		// Create base HTTPError
+		httpErr := HTTPError{
+			Code:                       statusCode,
+			Status:                     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+			Message:                    fmt.Sprintf("%s %s", errorPayload.Error, errorPayload.ErrorDescription),
+			ErrorCode:                  errorPayload.Error,
+			PendingAuthenticationToken: errorPayload.PendingAuthenticationToken,
+			ConnectionIDs:              errorPayload.ConnectionIDs,
+			SSOConnectionIDs:           errorPayload.SSOConnectionIDs,
+			AuthMethods:                errorPayload.AuthMethods,
+			RawBody:                    string(b),
+		}
+
+		// Return appropriate structured error based on error type
+		switch errorPayload.Error {
+		case SSORequiredCode:
+			return &SSORequiredError{
+				HTTPError:                  httpErr,
+				ErrorCode:                  errorPayload.Error,
+				ErrorDescription:           errorPayload.ErrorDescription,
+				Email:                      errorPayload.Email,
+				ConnectionIDs:              errorPayload.ConnectionIDs,
+				PendingAuthenticationToken: errorPayload.PendingAuthenticationToken,
+			}
+		case OrganizationAuthenticationMethodsRequiredCode:
+			return &OrganizationAuthenticationMethodsRequiredError{
+				HTTPError:                  httpErr,
+				ErrorCode:                  errorPayload.Error,
+				ErrorDescription:           errorPayload.ErrorDescription,
+				Email:                      errorPayload.Email,
+				SSOConnectionIDs:           errorPayload.SSOConnectionIDs,
+				AuthMethods:                errorPayload.AuthMethods,
+				PendingAuthenticationToken: errorPayload.PendingAuthenticationToken,
+			}
+		}
+	}
+
+	// If no specific error type matches, return nil to fall back to generic parsing
+	return nil
 }
 
 // HTTPError represents an http error.
@@ -144,6 +311,13 @@ type HTTPError struct {
 	RawBody                    string
 	PendingAuthenticationToken string
 	EmailVerificationID        string
+	// Authentication error specific fields
+	AuthenticationFactors []AuthenticationFactor `json:"authentication_factors,omitempty"`
+	Organizations         []Organization         `json:"organizations,omitempty"`
+	ConnectionIDs         []string               `json:"connection_ids,omitempty"`
+	SSOConnectionIDs      []string               `json:"sso_connection_ids,omitempty"`
+	AuthMethods           map[string]bool        `json:"auth_methods,omitempty"`
+	User                  *User                  `json:"user,omitempty"`
 }
 
 type FieldError struct {


### PR DESCRIPTION
## Description

# Add Structured Authentication Error Handling

This PR implements structured error handling for AuthKit authentication errors, providing type-safe error types and helper functions for better developer experience.

## Changes

**New Files:**
- `pkg/workos_errors/authentication_errors.go` - Structured error types and helper functions
- `pkg/workos_errors/authentication_errors_test.go` - Comprehensive test coverage

**Modified Files:**
- `pkg/workos_errors/http.go` - Extended `HTTPError` struct and added authentication error parsing

## Features Added

**Structured Error Types:**
- `EmailVerificationRequiredError`
- `MFAEnrollmentError` 
- `MFAChallengeError`
- `OrganizationSelectionRequiredError`
- `SSORequiredError`
- `OrganizationAuthenticationMethodsRequiredError`

**Helper Functions:**
- Type checking: `IsEmailVerificationRequired(err)`, `IsMFAEnrollment(err)`, etc.
- Type assertion: `AsEmailVerificationRequired(err)`, `AsMFAEnrollment(err)`, etc.

**Enhanced Error Parsing:**
- Automatic detection and parsing of authentication errors from API responses
- Fallback to generic error handling for non-authentication errors

## Benefits
- **Type Safety**: Developers can use type assertions and helper functions
- **Better DX**: Clean, readable error handling patterns
- **Backwards Compatible**: All existing code continues to work
- **Consistent API**: Follows Go standard library patterns

## Usage Example
```go
err := client.AuthenticateUser(ctx, opts)
if workos_errors.IsEmailVerificationRequired(err) {
    if emailErr, ok := workos_errors.AsEmailVerificationRequired(err); ok {
        // Access specific fields: emailErr.Email, emailErr.PendingAuthenticationToken, etc.
    }
}
```
```

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
