### PR TITLE
Fix and align list_metadata JSON tags across SDK list responses

### DIFF
--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -176,7 +176,7 @@ type ListUsersResponse struct {
 	Data []User `json:"data"`
 
 	// Cursor pagination options.
-	ListMetadata common.ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"list_metadata"`
 }
 
 // ListUsers gets a list of provisioned Users for a Directory.
@@ -285,7 +285,7 @@ type ListGroupsResponse struct {
 	Data []Group `json:"data"`
 
 	// Cursor pagination options.
-	ListMetadata common.ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"list_metadata"`
 }
 
 // ListGroups gets a list of provisioned Groups for a Directory Endpoint.
@@ -536,7 +536,7 @@ type ListDirectoriesResponse struct {
 	Data []Directory `json:"data"`
 
 	// Cursor pagination options.
-	ListMetadata common.ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"list_metadata"`
 }
 
 // ListDirectories gets details of existing Directories.

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -595,3 +595,39 @@ func deleteDirectoryTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 
 }
+
+func TestListUsers_UnmarshalSnakeCaseListMetadata(t *testing.T) {
+	raw := []byte(`{
+        "data": [],
+        "list_metadata": { "before": "", "after": "user_abc123" }
+    }`)
+
+	var resp ListUsersResponse
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	require.Equal(t, "user_abc123", resp.ListMetadata.After)
+	require.Equal(t, "", resp.ListMetadata.Before)
+}
+
+func TestListGroups_UnmarshalSnakeCaseListMetadata(t *testing.T) {
+	raw := []byte(`{
+        "data": [],
+        "list_metadata": { "before": "", "after": "group_abc123" }
+    }`)
+
+	var resp ListGroupsResponse
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	require.Equal(t, "group_abc123", resp.ListMetadata.After)
+	require.Equal(t, "", resp.ListMetadata.Before)
+}
+
+func TestListDirectories_UnmarshalSnakeCaseListMetadata(t *testing.T) {
+	raw := []byte(`{
+        "data": [],
+        "list_metadata": { "before": "", "after": "dir_abc123" }
+    }`)
+
+	var resp ListDirectoriesResponse
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	require.Equal(t, "dir_abc123", resp.ListMetadata.After)
+	require.Equal(t, "", resp.ListMetadata.Before)
+}

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -148,7 +148,7 @@ type ListOrganizationsResponse struct {
 	Data []Organization `json:"data"`
 
 	// Cursor pagination options.
-	ListMetadata common.ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"list_metadata"`
 }
 
 type OrganizationDomainDataState string

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -763,3 +763,15 @@ func listOrganizationRolesTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(body)
 }
+
+func TestListOrganizations_UnmarshalSnakeCaseListMetadata(t *testing.T) {
+	raw := []byte(`{
+        "data": [],
+        "list_metadata": { "before": "", "after": "org_abc123" }
+    }`)
+
+	var resp ListOrganizationsResponse
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	require.Equal(t, "org_abc123", resp.ListMetadata.After)
+	require.Equal(t, "", resp.ListMetadata.Before)
+}

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -493,7 +493,7 @@ type ListConnectionsResponse struct {
 	Data []Connection `json:"data"`
 
 	// Cursor pagination options.
-	ListMetadata common.ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"list_metadata"`
 }
 
 // ListConnections gets details of existing Connections.

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -525,3 +525,15 @@ func listConnectionsTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(body)
 }
+
+func TestListConnections_UnmarshalSnakeCaseListMetadata(t *testing.T) {
+	raw := []byte(`{
+        "data": [],
+        "list_metadata": { "before": "", "after": "conn_abc123" }
+    }`)
+
+	var resp ListConnectionsResponse
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	require.Equal(t, "conn_abc123", resp.ListMetadata.After)
+	require.Equal(t, "", resp.ListMetadata.Before)
+}

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -531,7 +531,7 @@ type ListInvitationsResponse struct {
 	Data []Invitation `json:"data"`
 
 	// Cursor to paginate through the list of Invitations
-	ListMetadata common.ListMetadata `json:"listMetadata"`
+	ListMetadata common.ListMetadata `json:"list_metadata"`
 }
 
 type ListInvitationsOpts struct {

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -3416,3 +3416,15 @@ func RevokeSessionTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(body)
 }
+
+func TestListInvitations_UnmarshalSnakeCaseListMetadata(t *testing.T) {
+	raw := []byte(`{
+        "data": [],
+        "list_metadata": { "before": null, "after": "invitation_abc123" }
+    }`)
+
+	var resp ListInvitationsResponse
+	require.NoError(t, json.Unmarshal(raw, &resp))
+	require.Equal(t, "invitation_abc123", resp.ListMetadata.After)
+	require.Equal(t, "", resp.ListMetadata.Before)
+}


### PR DESCRIPTION
## Description

### Summary
- **Problem**: The API returns pagination under `list_metadata` (snake_case), but `ListInvitationsResponse.ListMetadata` used `json:"listMetadata"` (camelCase), causing empty pagination cursors.
- **Fix**: Updated JSON tags to `json:"list_metadata"` and added raw JSON regression tests to prevent regressions.
- **Scope**: Fixed in `usermanagement` and aligned similar responses in `organizations`, `sso`, and `directorysync`.

### What changed
- **User Management**
  - `pkg/usermanagement/client.go`
    - `ListInvitationsResponse.ListMetadata`: `json:"listMetadata"` → `json:"list_metadata"`.
  - `pkg/usermanagement/client_test.go`
    - Added `TestListInvitations_UnmarshalSnakeCaseListMetadata` (raw JSON decode; asserts cursors).
- **Organizations**
  - `pkg/organizations/client.go`: `ListOrganizationsResponse.ListMetadata` → `json:"list_metadata"`.
  - `pkg/organizations/client_test.go`: Added raw JSON decode test.
- **SSO**
  - `pkg/sso/client.go`: `ListConnectionsResponse.ListMetadata` → `json:"list_metadata"`.
  - `pkg/sso/client_test.go`: Added raw JSON decode test.
- **Directory Sync**
  - `pkg/directorysync/client.go`:
    - `ListUsersResponse.ListMetadata` → `json:"list_metadata"`.
    - `ListGroupsResponse.ListMetadata` → `json:"list_metadata"`.
    - `ListDirectoriesResponse.ListMetadata` → `json:"list_metadata"`.
  - `pkg/directorysync/client_test.go`: Added raw JSON decode tests for all three responses.
- Note: Other user management list responses (e.g., `ListUsersResponse`, `ListOrganizationMembershipsResponse`) already used `json:"list_metadata"` and required no changes.

### Why this was needed
- Real API responses include non-empty `list_metadata.after`, but the SDK left `ListMetadata` empty due to the tag mismatch. This broke pagination for `ListInvitations`.

### Tests
- Added raw JSON decode tests that feed API-shaped payloads directly (no struct marshaling) to ensure we map `list_metadata` correctly.
- Ran full test suite:
  - All tests pass across updated packages.
  - Known, unrelated failure in `pkg/vault` remains due to `math/rand/v2` (requires Go 1.22+).

### Backwards compatibility
- **No breaking changes**. Only JSON tags on response structs were corrected to match the API. Existing behavior improves (pagination cursors now populated).



## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
