### PR TITLE
Fix: Revert breaking change in v4.46.0 to maintain backward compatibility

### DIFF
--- a/pkg/usermanagement/README.md
+++ b/pkg/usermanagement/README.md
@@ -13,18 +13,3 @@ go get -u github.com/workos/workos-go/v4/pkg/usermanagement
 ## How it works
 
 See the [User Management integration guide](https://workos.com/docs/user-management/).
-
-### Update user metadata and remove a key by sending JSON null
-
-To set a metadata value to null (and remove it server-side), pass a `nil` pointer for that key. The `Metadata` field accepts `map[string]*string`.
-
-```go
-lang := "en"
-user, err := usermanagement.UpdateUser(ctx, usermanagement.UpdateUserOpts{
-  User: "user_123",
-  Metadata: map[string]*string{
-    "language": &lang,
-    "legacy_code": nil, // serializes as JSON null
-  },
-})
-```

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -213,15 +213,15 @@ const (
 
 type UpdateUserOpts struct {
 	User             string
-	Email            string             `json:"email,omitempty"`
-	FirstName        string             `json:"first_name,omitempty"`
-	LastName         string             `json:"last_name,omitempty"`
-	EmailVerified    bool               `json:"email_verified,omitempty"`
-	Password         string             `json:"password,omitempty"`
-	PasswordHash     string             `json:"password_hash,omitempty"`
-	PasswordHashType PasswordHashType   `json:"password_hash_type,omitempty"`
-	ExternalID       string             `json:"external_id,omitempty"`
-	Metadata         map[string]*string `json:"metadata,omitempty"`
+	Email            string            `json:"email,omitempty"`
+	FirstName        string            `json:"first_name,omitempty"`
+	LastName         string            `json:"last_name,omitempty"`
+	EmailVerified    bool              `json:"email_verified,omitempty"`
+	Password         string            `json:"password,omitempty"`
+	PasswordHash     string            `json:"password_hash,omitempty"`
+	PasswordHashType PasswordHashType  `json:"password_hash_type,omitempty"`
+	ExternalID       string            `json:"external_id,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
 }
 
 type DeleteUserOpts struct {

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -526,64 +526,6 @@ func updateUserTestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(body)
 }
 
-func TestUpdateUser_MetadataJSONSerialization_StringValues(t *testing.T) {
-	lang := "en"
-	opts := UpdateUserOpts{
-		Metadata: map[string]*string{
-			"language": &lang,
-		},
-	}
-
-	b, err := json.Marshal(opts)
-	require.NoError(t, err)
-
-	var got map[string]interface{}
-	require.NoError(t, json.Unmarshal(b, &got))
-
-	meta, ok := got["metadata"].(map[string]interface{})
-	require.True(t, ok)
-	require.Equal(t, "en", meta["language"])
-}
-
-func TestUpdateUser_MetadataJSONSerialization_NilValueAsNull(t *testing.T) {
-	opts := UpdateUserOpts{
-		Metadata: map[string]*string{
-			"legacy_code": nil,
-		},
-	}
-
-	b, err := json.Marshal(opts)
-	require.NoError(t, err)
-
-	// Check raw contains null for the key
-	require.Contains(t, string(b), "\"legacy_code\":null")
-
-	var got map[string]interface{}
-	require.NoError(t, json.Unmarshal(b, &got))
-
-	meta, ok := got["metadata"].(map[string]interface{})
-	require.True(t, ok)
-	// JSON null becomes a nil interface value when decoding into map[string]any
-	_, present := meta["legacy_code"]
-	require.True(t, present)
-	require.Nil(t, meta["legacy_code"])
-}
-
-func TestUpdateUser_MetadataJSONSerialization_EmptyMapOmitted(t *testing.T) {
-	opts := UpdateUserOpts{
-		Metadata: map[string]*string{},
-	}
-
-	b, err := json.Marshal(opts)
-	require.NoError(t, err)
-
-	var got map[string]interface{}
-	require.NoError(t, json.Unmarshal(b, &got))
-
-	_, present := got["metadata"]
-	require.False(t, present)
-}
-
 func TestDeleteUser(t *testing.T) {
 	tests := []struct {
 		scenario string


### PR DESCRIPTION
## Summary
- Reverts PR #453 which introduced a breaking change in v4.46.0
- Restores `UpdateUserOpts.Metadata` field type from `map[string]*string` back to `map[string]string`
- This maintains backward compatibility for v4.x users

## Context
PR #453 changed the `Metadata` field type which breaks compilation for existing users upgrading from v4.45.1 to v4.46.0. This violates SemVer principles as breaking changes should only be introduced in major version releases.

## Plan
1. Release this as v4.46.1 to fix the breaking change
2. Re-introduce the metadata removal functionality properly in v5.0.0

## Test Plan
- [x] Verified that `UpdateUserOpts.Metadata` accepts `map[string]string` again
- [x] Confirmed existing code will compile without modifications