### PR TITLE
Update version to v4.46.1

### DIFF
--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.46.0"
+	Version = "v4.46.1"
 )


### PR DESCRIPTION
## Summary
Bumps version to v4.46.1 following the revert of the breaking change in PR #455.

## Context
- v4.46.0 introduced an unintended breaking change to `UpdateUserOpts.Metadata` 
- PR #455 reverted this breaking change
- This PR updates the version number to v4.46.1 for the fixed release

## Changes
- Updates version constant from v4.46.0 to v4.46.1

## Notes
- The breaking change functionality will be properly introduced in v5.0.0
- Users on v4.46.0 should upgrade to v4.46.1 to restore compatibility