### PR TITLE
feat: Migrate to v5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WorkOS Go Library
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/workos/workos-go/v4.svg)](https://pkg.go.dev/github.com/workos/workos-go/v4)
+[![Go Reference](https://pkg.go.dev/badge/github.com/workos/workos-go/v5.svg)](https://pkg.go.dev/github.com/workos/workos-go/v5)
 
 The WorkOS library for Go provides convenient access to the WorkOS API from applications written in Go.
 
@@ -13,7 +13,7 @@ See the [API Reference](https://workos.com/docs/reference/client-libraries) for 
 Install the package with:
 
 ```bash
-go get -u github.com/workos/workos-go/v4
+go get -u github.com/workos/workos-go/v5
 ```
 
 ## Configuration
@@ -28,8 +28,8 @@ Or, you can configure it programmatically before your application starts:
 
 ```go
 import (
-    "github.com/workos/workos-go/v4/pkg/sso"
-    "github.com/workos/workos-go/v4/pkg/directorysync"
+    "github.com/workos/workos-go/v5/pkg/sso"
+    "github.com/workos/workos-go/v5/pkg/directorysync"
 )
 
 func main() {
@@ -47,12 +47,12 @@ The WorkOS Go library is organized into focused packages. Import only what you n
 
 ```go
 import (
-    "github.com/workos/workos-go/v4/pkg/sso"            // Single Sign-On
-    "github.com/workos/workos-go/v4/pkg/directorysync"  // Directory Sync (SCIM)  
-    "github.com/workos/workos-go/v4/pkg/usermanagement" // User Management
-    "github.com/workos/workos-go/v4/pkg/auditlogs"      // Audit Logs
-    "github.com/workos/workos-go/v4/pkg/organizations"  // Organizations
-    "github.com/workos/workos-go/v4/pkg/webhooks"       // Webhooks
+    "github.com/workos/workos-go/v5/pkg/sso"            // Single Sign-On
+    "github.com/workos/workos-go/v5/pkg/directorysync"  // Directory Sync (SCIM)  
+    "github.com/workos/workos-go/v5/pkg/usermanagement" // User Management
+    "github.com/workos/workos-go/v5/pkg/auditlogs"      // Audit Logs
+    "github.com/workos/workos-go/v5/pkg/organizations"  // Organizations
+    "github.com/workos/workos-go/v5/pkg/webhooks"       // Webhooks
 )
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/workos/workos-go/v4
+module github.com/workos/workos-go/v5
 
 go 1.13
 

--- a/internal/workos/workos.go
+++ b/internal/workos/workos.go
@@ -2,5 +2,5 @@ package workos
 
 const (
 	// Version represents the SDK version number.
-	Version = "v4.46.1"
+	Version = "v5.0.0"
 )

--- a/pkg/auditlogs/README.md
+++ b/pkg/auditlogs/README.md
@@ -1,13 +1,13 @@
 # auditlogs
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/auditlogs)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v5/pkg/auditlogs)
 
 A Go package to send audit log events to WorkOS.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/auditlogs
+go get -u github.com/workos/workos-go/v5/pkg/auditlogs
 ```
 
 ## How it works
@@ -15,7 +15,7 @@ go get -u github.com/workos/workos-go/v4/pkg/auditlogs
 ```go
 package main
 
-import "github.com/workos/workos-go/v4/pkg/auditlogs"
+import "github.com/workos/workos-go/v5/pkg/auditlogs"
 
 func main() {
 	auditlogs.SetAPIKey("my_api_key")

--- a/pkg/auditlogs/client.go
+++ b/pkg/auditlogs/client.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v4/internal/workos"
+	"github.com/workos/workos-go/v5/internal/workos"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/auditlogs/client_test.go
+++ b/pkg/auditlogs/client_test.go
@@ -3,7 +3,7 @@ package auditlogs
 import (
 	"context"
 	"encoding/json"
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"

--- a/pkg/directorysync/README.md
+++ b/pkg/directorysync/README.md
@@ -1,13 +1,13 @@
 # directorysync
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/directorysync)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v5/pkg/directorysync)
 
 A Go package to make requests to the WorkOS Directory Sync API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/directorysync
+go get -u github.com/workos/workos-go/v5/pkg/directorysync
 ```
 
 ## How it works

--- a/pkg/directorysync/client.go
+++ b/pkg/directorysync/client.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v4/internal/workos"
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/internal/workos"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/directorysync/client_test.go
+++ b/pkg/directorysync/client_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 func TestListUsers(t *testing.T) {

--- a/pkg/directorysync/directorysync_test.go
+++ b/pkg/directorysync/directorysync_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 func TestDirectorySyncListUsers(t *testing.T) {

--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -5,7 +5,7 @@ A Go package to retrieve events from WorkOS.
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/events
+go get -u github.com/workos/workos-go/v5/pkg/events
 ```
 
 ## How it works
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/workos/workos-go/v4/pkg/events"
+	"github.com/workos/workos-go/v5/pkg/events"
 )
 
 func main() {

--- a/pkg/events/client.go
+++ b/pkg/events/client.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v4/internal/workos"
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/internal/workos"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/events/client_test.go
+++ b/pkg/events/client_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 func TestListEvents(t *testing.T) {

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 func TestEventsListEvents(t *testing.T) {

--- a/pkg/fga/client.go
+++ b/pkg/fga/client.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v4/internal/workos"
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/retryablehttp"
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/internal/workos"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/retryablehttp"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/fga/client_test.go
+++ b/pkg/fga/client_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/retryablehttp"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/retryablehttp"
 )
 
 func TestGetResource(t *testing.T) {

--- a/pkg/fga/fga_test.go
+++ b/pkg/fga/fga_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/retryablehttp"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/retryablehttp"
 )
 
 func TestFGAGetResource(t *testing.T) {

--- a/pkg/mfa/client.go
+++ b/pkg/mfa/client.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v4/internal/workos"
+	"github.com/workos/workos-go/v5/internal/workos"
 )
 
 // This represents the list of errors that could be raised when using the mfa package

--- a/pkg/organization_domains/README.md
+++ b/pkg/organization_domains/README.md
@@ -1,13 +1,13 @@
 # organization_domains
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/organization_domains)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v5/pkg/organization_domains)
 
 A Go package to make requests to the WorkOS Organization Domains API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/organization_domains
+go get -u github.com/workos/workos-go/v5/pkg/organization_domains
 ```
 
 ## How it works

--- a/pkg/organization_domains/client.go
+++ b/pkg/organization_domains/client.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v4/internal/workos"
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/internal/workos"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 )
 
 type OrganizationDomainState string

--- a/pkg/organizations/README.md
+++ b/pkg/organizations/README.md
@@ -1,13 +1,13 @@
 # organizations
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/organizations)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v5/pkg/organizations)
 
 A Go package to make requests to the WorkOS Organizations API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/organizations
+go get -u github.com/workos/workos-go/v5/pkg/organizations
 ```
 
 ## How it works

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -9,13 +9,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v4/pkg/roles"
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/roles"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v4/internal/workos"
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/organization_domains"
+	"github.com/workos/workos-go/v5/internal/workos"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/organization_domains"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/roles"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/roles"
 )
 
 func TestGetOrganization(t *testing.T) {

--- a/pkg/organizations/organizations_test.go
+++ b/pkg/organizations/organizations_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/roles"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/roles"
 )
 
 func TestOrganizationsGetOrganization(t *testing.T) {

--- a/pkg/passwordless/README.md
+++ b/pkg/passwordless/README.md
@@ -1,13 +1,13 @@
 # passwordless
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/passwordless)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v5/pkg/passwordless)
 
 A Go package to make requests to the WorkOS Magic Link API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/passwordless
+go get -u github.com/workos/workos-go/v5/pkg/passwordless
 ```
 
 ## How it works

--- a/pkg/passwordless/client.go
+++ b/pkg/passwordless/client.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v4/internal/workos"
+	"github.com/workos/workos-go/v5/internal/workos"
 )
 
 // Client represents a client that performs Passwordless requests to the WorkOS API.

--- a/pkg/portal/README.md
+++ b/pkg/portal/README.md
@@ -1,13 +1,13 @@
 # portal
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/portal)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v5/pkg/portal)
 
 A Go package to make requests to the WorkOS Admin Portal API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/portal
+go get -u github.com/workos/workos-go/v5/pkg/portal
 ```
 
 ## How it works

--- a/pkg/portal/client.go
+++ b/pkg/portal/client.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v4/internal/workos"
+	"github.com/workos/workos-go/v5/internal/workos"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/roles/README.md
+++ b/pkg/roles/README.md
@@ -1,13 +1,13 @@
 # roles
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/roles)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v5/pkg/roles)
 
 A Go package to make requests to the WorkOS Roles API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/roles
+go get -u github.com/workos/workos-go/v5/pkg/roles
 ```
 
 ## How it works

--- a/pkg/sso/README.md
+++ b/pkg/sso/README.md
@@ -1,13 +1,13 @@
 # sso
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/sso)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v5/pkg/sso)
 
 A go package to request WorkOS SSO API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/sso
+go get -u github.com/workos/workos-go/v5/pkg/sso
 ```
 
 ## How it works

--- a/pkg/sso/client.go
+++ b/pkg/sso/client.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v4/internal/workos"
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/internal/workos"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/sso/client_test.go
+++ b/pkg/sso/client_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 func TestClientAuthorizeURL(t *testing.T) {

--- a/pkg/sso/sso_test.go
+++ b/pkg/sso/sso_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 func TestLogin(t *testing.T) {

--- a/pkg/usermanagement/README.md
+++ b/pkg/usermanagement/README.md
@@ -1,13 +1,13 @@
 # usermanagement
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/usermanagement)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v5/pkg/usermanagement)
 
 A go package wrapping the WorkOS User Management API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/usermanagement
+go get -u github.com/workos/workos-go/v5/pkg/usermanagement
 ```
 
 ## How it works

--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v4/internal/workos"
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/mfa"
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/internal/workos"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/mfa"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/usermanagement/client_test.go
+++ b/pkg/usermanagement/client_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/mfa"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/mfa"
 )
 
 func TestGetUser(t *testing.T) {

--- a/pkg/usermanagement/usermanagement_test.go
+++ b/pkg/usermanagement/usermanagement_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/mfa"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/mfa"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"github.com/workos/workos-go/v4/internal/workos"
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/retryablehttp"
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/internal/workos"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/retryablehttp"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/vault/client_test.go
+++ b/pkg/vault/client_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v4/pkg/common"
-	"github.com/workos/workos-go/v4/pkg/retryablehttp"
+	"github.com/workos/workos-go/v5/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/retryablehttp"
 )
 
 func TestListObjects(t *testing.T) {

--- a/pkg/webhooks/client_test.go
+++ b/pkg/webhooks/client_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	"github.com/workos/workos-go/v4/pkg/webhooks"
+	"github.com/workos/workos-go/v5/pkg/webhooks"
 	"strconv"
 	"testing"
 	"time"

--- a/pkg/widgets/README.md
+++ b/pkg/widgets/README.md
@@ -1,13 +1,13 @@
 # widgets
 
-[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v4/pkg/widgets)
+[![Go Report Card](https://img.shields.io/badge/dev-reference-007d9c?logo=go&logoColor=white&style=flat)](https://pkg.go.dev/github.com/workos/workos-go/v5/pkg/widgets)
 
 A Go package to make requests to the WorkOS Widgets API.
 
 ## Install
 
 ```sh
-go get -u github.com/workos/workos-go/v4/pkg/widgets
+go get -u github.com/workos/workos-go/v5/pkg/widgets
 ```
 
 ## How it works

--- a/pkg/widgets/client.go
+++ b/pkg/widgets/client.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 
-	"github.com/workos/workos-go/v4/internal/workos"
+	"github.com/workos/workos-go/v5/internal/workos"
 )
 
 // ResponseLimit is the default number of records to limit a response to.

--- a/pkg/workos_errors/authentication_errors.go
+++ b/pkg/workos_errors/authentication_errors.go
@@ -1,7 +1,7 @@
 package workos_errors
 
 import (
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 // Authentication error code constants

--- a/pkg/workos_errors/errors_test.go
+++ b/pkg/workos_errors/errors_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/workos/workos-go/v4/pkg/workos_errors"
+	"github.com/workos/workos-go/v5/pkg/workos_errors"
 )
 
 func TestIsBadRequest(t *testing.T) {

--- a/pkg/workos_errors/http.go
+++ b/pkg/workos_errors/http.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/workos/workos-go/v4/pkg/common"
+	"github.com/workos/workos-go/v5/pkg/common"
 )
 
 // TryGetHTTPError returns an error when the http response contains invalid


### PR DESCRIPTION
## Summary
Completes the migration to v5.0.0 of the WorkOS Go SDK.

## Changes
1. **Module path migration**
   - Updated go.mod from `v4` to `v5`
   - Updated all import paths throughout the codebase
   - Updated all documentation references

2. **Version bump**
   - Updated version constant from `v4.46.1` to `v5.0.0`

## Breaking Changes Summary
The v5 release includes the following breaking change:
- `UpdateUserOpts.Metadata` field type changed from `map[string]string` to `map[string]*string` (introduced in PR #457)
- This allows setting metadata values to `nil` to remove them server-side

## Migration Guide for Users
```go
// v4 (old)
import "github.com/workos/workos-go/v4/pkg/usermanagement"

opts := usermanagement.UpdateUserOpts{
    User: "user_123",
    Metadata: map[string]string{
        "department": "Engineering",
    },
}

// v5 (new)
import "github.com/workos/workos-go/v5/pkg/usermanagement"

dept := "Engineering"
opts := usermanagement.UpdateUserOpts{
    User: "user_123",
    Metadata: map[string]*string{
        "department": &dept,
        "old_field": nil,  // Removes this field
    },
}
```

## Release Process
After this PR is merged:
1. Tag the release as `v5.0.0`
2. Create GitHub release with migration guide
3. Update documentation

## Related PRs
- #453 - Original metadata removal feature
- #455 - Revert for v4.46.1
- #456 - v4.46.1 version bump (fixing the breaking change)
- #457 - Re-introduced metadata removal feature