### PR TITLE
updated the UpdateOrganizationOpts fields to optional

### DIFF
--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -202,7 +202,7 @@ type UpdateOrganizationOpts struct {
 	Organization string
 
 	// Name of the Organization.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// Whether Connections within the Organization allow profiles that are
 	// outside of the Organization's configured User Email Domains.

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -202,7 +202,7 @@ type UpdateOrganizationOpts struct {
 	Organization string
 
 	// Name of the Organization.
-	Name string
+	Name string `json:"name"`
 
 	// Whether Connections within the Organization allow profiles that are
 	// outside of the Organization's configured User Email Domains.
@@ -216,16 +216,16 @@ type UpdateOrganizationOpts struct {
 	Domains []string
 
 	// Domains of the Organization.
-	DomainData []OrganizationDomainData `json:"domain_data"`
+	DomainData []OrganizationDomainData `json:"domain_data,omitempty"`
 
 	// The Organization's external id.
-	ExternalID string `json:"external_id"`
+	ExternalID string `json:"external_id,omitempty"`
 
 	// The Organization's Stripe Customer ID.
 	StripeCustomerID string `json:"stripe_customer_id,omitempty"`
 
 	// The Organization's metadata.
-	Metadata map[string]string `json:"metadata"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // ListOrganizationsOpts contains the options to request Organizations.


### PR DESCRIPTION
## Description

`Organization.UpdateOrganization` wasn't updating the name, made `DomainData`, `ExternalID`, and `Metadata` optional params by  adding `omitempty` to the struct values in `UpdateOrganizationOpts`

## Documentation

no

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
