### PR TITLE
feat(user-management): add DirectoryManaged to OrganizationMembership

### DIFF
--- a/pkg/usermanagement/client.go
+++ b/pkg/usermanagement/client.go
@@ -137,6 +137,9 @@ type OrganizationMembership struct {
 	// The Status of the Organization.
 	Status OrganizationMembershipStatus `json:"status"`
 
+	// Whether the membership is managed by a directory sync connection.
+	DirectoryManaged bool `json:"directory_managed"`
+
 	// CustomAttributes contains custom attributes from the IdP
 	CustomAttributes map[string]interface{} `json:"custom_attributes"`
 


### PR DESCRIPTION
## Summary
- Add `DirectoryManaged bool` field with `json:"directory_managed"` tag to `OrganizationMembership` struct
- This field indicates whether an organization membership is managed by a directory sync connection

## Test plan
- [x] New field uses zero value (`false`) which is consistent with existing test fixtures
- [x] No test changes needed as `bool` defaults to `false` in Go
🤖 Generated with [Claude Code](https://claude.com/claude-code)