### PR TITLE
fix: allow clearing organization domains by sending empty arrays

### DIFF
--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -213,10 +213,10 @@ type UpdateOrganizationOpts struct {
 	// Domains of the Organization.
 	//
 	// Deprecated:  Use DomainData instead.
-	Domains []string `json:"domains"`
+	Domains []string `json:"domains,omitempty"`
 
 	// Domains of the Organization.
-	DomainData []OrganizationDomainData `json:"domain_data"`
+	DomainData []OrganizationDomainData `json:"domain_data,omitempty"`
 
 	// The Organization's external id.
 	ExternalID string `json:"external_id,omitempty"`
@@ -226,6 +226,38 @@ type UpdateOrganizationOpts struct {
 
 	// The Organization's metadata.
 	Metadata map[string]*string `json:"metadata,omitempty"`
+}
+
+// MarshalJSON implements custom JSON marshaling for UpdateOrganizationOpts.
+// The standard omitempty tag omits both nil and empty slices, making it
+// impossible to send an empty array to clear domains. This marshaler omits
+// Domains and DomainData only when nil, while preserving empty slices as [].
+func (o UpdateOrganizationOpts) MarshalJSON() ([]byte, error) {
+	m := make(map[string]interface{})
+
+	if o.Name != "" {
+		m["name"] = o.Name
+	}
+	if o.AllowProfilesOutsideOrganization {
+		m["allow_profiles_outside_organization"] = o.AllowProfilesOutsideOrganization
+	}
+	if o.Domains != nil {
+		m["domains"] = o.Domains
+	}
+	if o.DomainData != nil {
+		m["domain_data"] = o.DomainData
+	}
+	if o.ExternalID != "" {
+		m["external_id"] = o.ExternalID
+	}
+	if o.StripeCustomerID != "" {
+		m["stripe_customer_id"] = o.StripeCustomerID
+	}
+	if o.Metadata != nil {
+		m["metadata"] = o.Metadata
+	}
+
+	return json.Marshal(m)
 }
 
 // ListOrganizationsOpts contains the options to request Organizations.

--- a/pkg/organizations/client.go
+++ b/pkg/organizations/client.go
@@ -213,10 +213,10 @@ type UpdateOrganizationOpts struct {
 	// Domains of the Organization.
 	//
 	// Deprecated:  Use DomainData instead.
-	Domains []string `json:"domains,omitempty"`
+	Domains []string `json:"domains"`
 
 	// Domains of the Organization.
-	DomainData []OrganizationDomainData `json:"domain_data,omitempty"`
+	DomainData []OrganizationDomainData `json:"domain_data"`
 
 	// The Organization's external id.
 	ExternalID string `json:"external_id,omitempty"`

--- a/pkg/organizations/client_test.go
+++ b/pkg/organizations/client_test.go
@@ -624,6 +624,87 @@ func TestUpdateOrganization(t *testing.T) {
 	}
 }
 
+func TestUpdateOrganizationOptsMarshalJSON(t *testing.T) {
+	tests := []struct {
+		scenario    string
+		opts        UpdateOrganizationOpts
+		shouldExist map[string]bool
+		wantValue   map[string]string
+	}{
+		{
+			scenario: "nil Domains and DomainData are omitted",
+			opts: UpdateOrganizationOpts{
+				Name: "Foo Corp",
+			},
+			shouldExist: map[string]bool{
+				"domains":     false,
+				"domain_data": false,
+				"name":        true,
+			},
+		},
+		{
+			scenario: "empty Domains slice serializes as empty array",
+			opts: UpdateOrganizationOpts{
+				Name:    "Foo Corp",
+				Domains: []string{},
+			},
+			shouldExist: map[string]bool{
+				"domains": true,
+				"name":    true,
+			},
+			wantValue: map[string]string{
+				"domains": "[]",
+			},
+		},
+		{
+			scenario: "empty DomainData slice serializes as empty array",
+			opts: UpdateOrganizationOpts{
+				Name:       "Foo Corp",
+				DomainData: []OrganizationDomainData{},
+			},
+			shouldExist: map[string]bool{
+				"domain_data": true,
+				"name":        true,
+			},
+			wantValue: map[string]string{
+				"domain_data": "[]",
+			},
+		},
+		{
+			scenario: "populated Domains serializes normally",
+			opts: UpdateOrganizationOpts{
+				Name:    "Foo Corp",
+				Domains: []string{"foo.com"},
+			},
+			shouldExist: map[string]bool{
+				"domains": true,
+			},
+			wantValue: map[string]string{
+				"domains": `["foo.com"]`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			data, err := json.Marshal(test.opts)
+			require.NoError(t, err)
+
+			var raw map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(data, &raw))
+
+			for key, shouldExist := range test.shouldExist {
+				_, exists := raw[key]
+				require.Equal(t, shouldExist, exists, "key %q existence mismatch", key)
+			}
+
+			for key, want := range test.wantValue {
+				require.JSONEq(t, want, string(raw[key]), "key %q value mismatch", key)
+			}
+		})
+	}
+}
+
 func updateOrganizationTestHandler(w http.ResponseWriter, r *http.Request) {
 	auth := r.Header.Get("Authorization")
 	if auth != "Bearer test" {


### PR DESCRIPTION
## Summary

  - Remove `omitempty` from `Domains` and `DomainData` JSON tags in `UpdateOrganizationOpts`
  - In Go, `json:",omitempty"` omits both `nil` and empty slices (`[]string{}`), making it impossible to send an empty array to the API to clear an organization's domains
  - After this fix:
    - `nil` → serializes as `null` (no change on API side)
    - `[]string{}` → serializes as `[]` (clears domains)
    - `[]string{"foo.com"}` → serializes as `["foo.com"]` (sets domains)

  ## Test plan

  - [x] `go test ./pkg/organizations/...` passes