### PR TITLE
fix: parse webhook/action signature timestamps as milliseconds

### DIFF
--- a/actions_helper.go
+++ b/actions_helper.go
@@ -58,7 +58,7 @@ func (a *ActionsHelper) VerifyHeader(payload string, sigHeader string, secret st
 		return ErrWebhookInvalidTimestamp
 	}
 
-	signedAt := time.Unix(ts, 0)
+	signedAt := time.UnixMilli(ts)
 	now := a.now()
 	if now.Sub(signedAt).Abs() > a.tolerance {
 		return ErrWebhookOutsideTolerance
@@ -115,7 +115,7 @@ func (a *ActionsHelper) SignResponse(actionType ActionType, verdict ActionVerdic
 	b64Payload := base64.StdEncoding.EncodeToString(jsonBytes)
 
 	now := a.now()
-	timestamp := strconv.FormatInt(now.Unix(), 10)
+	timestamp := strconv.FormatInt(now.UnixMilli(), 10)
 
 	sig := ComputeWebhookSignature(secret, timestamp, b64Payload)
 

--- a/actions_helper_test.go
+++ b/actions_helper_test.go
@@ -30,7 +30,7 @@ func computeTestActionSignature(secret, timestamp, payload string) string {
 
 // buildActionSigHeader builds a "t=...,v1=..." signature header for testing.
 func buildActionSigHeader(secret, payload string, ts time.Time) string {
-	timestamp := strconv.FormatInt(ts.Unix(), 10)
+	timestamp := strconv.FormatInt(ts.UnixMilli(), 10)
 	sig := computeTestActionSignature(secret, timestamp, payload)
 	return fmt.Sprintf("t=%s,v1=%s", timestamp, sig)
 }
@@ -48,7 +48,7 @@ func TestActionsHelper_VerifyHeader_Valid(t *testing.T) {
 func TestActionsHelper_VerifyHeader_InvalidSignature(t *testing.T) {
 	payload := `{"type":"authentication"}`
 	now := time.Now()
-	timestamp := strconv.FormatInt(now.Unix(), 10)
+	timestamp := strconv.FormatInt(now.UnixMilli(), 10)
 	sigHeader := fmt.Sprintf("t=%s,v1=%s", timestamp, "invalidsig")
 
 	helper := workos.NewActionsHelper()

--- a/docs/V7_MIGRATION_GUIDE.md
+++ b/docs/V7_MIGRATION_GUIDE.md
@@ -395,19 +395,6 @@ Additional breaking changes:
   - `ErrNotSigned` -> `ErrWebhookNotSigned`
   - `ErrInvalidTimestamp` -> `ErrWebhookInvalidTimestamp`
   - `ErrOutsideTolerance` -> `ErrWebhookOutsideTolerance`
-- Test helpers that previously signed headers with millisecond timestamps need to switch to Unix seconds:
-
-Before:
-
-```go
-stringTime := strconv.FormatInt(now.Round(0).Unix()*1000, 10)
-```
-
-After:
-
-```go
-timestamp := strconv.FormatInt(now.Unix(), 10)
-```
 
 ## 7. Error Handling Was Flattened
 

--- a/webhook_verification.go
+++ b/webhook_verification.go
@@ -75,7 +75,7 @@ func (w *WebhookVerifier) VerifyPayload(sigHeader string, body string) (string, 
 		return "", ErrWebhookInvalidTimestamp
 	}
 
-	signedAt := time.Unix(ts, 0)
+	signedAt := time.UnixMilli(ts)
 	now := w.now()
 	if now.Sub(signedAt).Abs() > w.tolerance {
 		return "", ErrWebhookOutsideTolerance

--- a/webhook_verification_test.go
+++ b/webhook_verification_test.go
@@ -16,7 +16,7 @@ const testWebhookSecret = "whsec_test_secret_key"
 
 // buildWebhookSigHeader computes a valid signature header for testing.
 func buildWebhookSigHeader(secret string, body string, ts time.Time) string {
-	timestamp := strconv.FormatInt(ts.Unix(), 10)
+	timestamp := strconv.FormatInt(ts.UnixMilli(), 10)
 	sig := workos.ComputeWebhookSignature(secret, timestamp, body)
 	return fmt.Sprintf("t=%s, v1=%s", timestamp, sig)
 }
@@ -39,7 +39,7 @@ func TestVerifyPayload_ValidSignature(t *testing.T) {
 func TestVerifyPayload_InvalidSignature(t *testing.T) {
 	body := `{"event":"user.created"}`
 	now := time.Now()
-	timestamp := strconv.FormatInt(now.Unix(), 10)
+	timestamp := strconv.FormatInt(now.UnixMilli(), 10)
 
 	sigHeader := fmt.Sprintf("t=%s, v1=%s", timestamp, "badsignaturevalue")
 


### PR DESCRIPTION
## Description

WorkOS's format for `t=` in webhook and action signatures is a millisecond timestamp. The Go SDK was parsing it as seconds via `time.Unix(ts, 0)`, breaking signature verification for all webhooks and Actions.

Changes:
- `webhook_verification.go`: parse `t=` with `time.UnixMilli`
- `actions_helper.go`: same on the verify path; flip `SignResponse` to also emit millisecond `t=`
- Update test helpers in both files to sign with `UnixMilli`
- Update the migration guide removing references to this change

Comparable Node SDK behavior:
- https://github.com/workos/workos-node/blob/main/src/common/crypto/signature-provider.ts#L32
- https://github.com/workos/workos-node/blob/main/src/actions/actions.ts#L55

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/workos-go/pull/539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
