### PR TITLE
fix: set canonical User-Agent header format

### DIFF
--- a/client.go
+++ b/client.go
@@ -107,14 +107,7 @@ func (c *Client) request(
 
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
 		req.Header.Set("Content-Type", "application/json")
-		ua := "workos-go/" + Version
-		if c.appInfo.Name != "" {
-			ua += " " + c.appInfo.Name + "/" + c.appInfo.Version
-			if c.appInfo.URL != "" {
-				ua += " (" + c.appInfo.URL + ")"
-			}
-		}
-		req.Header.Set("User-Agent", ua)
+		req.Header.Set("User-Agent", "workos-go/"+Version)
 		if idempotencyKey != "" {
 			req.Header.Set("Idempotency-Key", idempotencyKey)
 		}


### PR DESCRIPTION
## Summary

The outgoing `User-Agent` header is now always `workos-go/v{Version}` — the canonical WorkOS Go SDK format used through the 6.x line. The 7.0.0 release inadvertently appended `appInfo` to the header in a way that no longer conformed.

### Behavior change

`WithAppInfo()` still parses for backwards compatibility, but the value no longer affects the `User-Agent` header. Callers relying on appInfo appearing in `User-Agent` will need to set a separate header via the request-options extra-headers mechanism.

## Test plan

- [x] `go test ./...` passes
- [ ] Confirm `User-Agent: workos-go/v{Version}` on a real outgoing request

🤖 Generated with [Claude Code](https://claude.com/claude-code)