### PR TITLE
feat: add API documentation site generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
           - 'stable'
           - 'oldstable'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: Publish API Docs
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - run: ./script/docs
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs/_site
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        id: deployment

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,9 +20,21 @@ jobs:
           go-version-file: go.mod
       - run: ./script/docs
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      - name: Archive site
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory docs/_site \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: docs/_site
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
   deploy:
     needs: build
     environment:

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -11,6 +11,6 @@ jobs:
   lint_pr_title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 'stable'
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ vars.SDK_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_BOT_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: Checkout release PR branch
         if: steps.find-pr.outputs.pr_branch != ''
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.find-pr.outputs.pr_branch }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.log
 *.vscode
 .idea/
+docs/_site/

--- a/script/docs
+++ b/script/docs
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")/.."
+rm -rf docs/_site
+mkdir -p docs/_site
+go run go101.org/golds@latest -gen -dir=docs/_site -nouses -wdpkgs-listing=solo ./...
+
+# Markdown output for AI agents
+go run github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest \
+  --output 'docs/_site/{{.Dir}}/index.md' \
+  ./...

--- a/script/docs-serve
+++ b/script/docs-serve
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")/.."
+if [ "${1:-}" = "--live" ]; then
+  exec go run go101.org/golds@latest -port=4000 -wdpkgs-listing=solo ./...
+fi
+if [ ! -d docs/_site ]; then
+  ./script/docs
+fi
+exec python3 -m http.server 4000 --directory docs/_site


### PR DESCRIPTION
## Summary
- Adds `script/docs` to build a static API docs site using `golds` (HTML) and `gomarkdoc` (Markdown for AI agents), output to `docs/_site/`.
- Adds `script/docs-serve` for local viewing — defaults to serving the built `docs/_site/` on port 4000, or `--live` runs `golds` directly for hot regeneration.
- Scopes `golds` to workos packages only via `-wdpkgs-listing=solo` so the index isn't polluted with stdlib/dep packages.
- Adds `.github/workflows/docs.yml` to publish to GitHub Pages on `v*` tag pushes (and via `workflow_dispatch`), with the standard pages/id-token permissions and a `pages` concurrency group.
- Bumps pinned GitHub Actions across existing workflows to current SHAs.
- Ignores `docs/_site/` in git.

## Test plan
- [ ] Run `./script/docs` locally and confirm `docs/_site/` is populated with HTML and per-package `index.md` files
- [ ] Run `./script/docs-serve` and browse http://localhost:4000
- [ ] Run `./script/docs-serve --live` and confirm the live golds server starts
- [ ] Trigger the `Publish API Docs` workflow via `workflow_dispatch` and confirm the Pages deploy succeeds
- [ ] Confirm existing CI/lint/release workflows still pass after the action SHA bumps
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/workos-go/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->