### PR TITLE
fix: v9 module path release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,6 +40,40 @@ jobs:
           ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
           token: ${{ steps.app-token.outputs.token }}
 
+      # Go modules require the module path and all import statements to
+      # include the major version (e.g. /v7). release-please doesn't handle
+      # this, so when a release PR bumps the major version we automatically
+      # rewrite go.mod, imports, and READMEs on the release PR branch.
+      - name: Migrate Go module path for major version bump
+        if: steps.release.outputs.pr
+        run: |
+          CURRENT_MAJOR=$(grep -oP 'module github\.com/workos/workos-go/v\K[0-9]+' go.mod)
+          NEW_VERSION=$(jq -r '."."' .release-please-manifest.json)
+          NEW_MAJOR="${NEW_VERSION%%.*}"
+
+          if [ "$CURRENT_MAJOR" = "$NEW_MAJOR" ]; then
+            echo "No major version change ($CURRENT_MAJOR → $NEW_MAJOR), skipping"
+            exit 0
+          fi
+
+          echo "Major version bump detected: v$CURRENT_MAJOR → v$NEW_MAJOR"
+
+          sed -i "s|module github.com/workos/workos-go/v${CURRENT_MAJOR}|module github.com/workos/workos-go/v${NEW_MAJOR}|" go.mod
+          find . -name '*.go' -not -path './.git/*' -type f \
+            -exec sed -i "s|github.com/workos/workos-go/v${CURRENT_MAJOR}|github.com/workos/workos-go/v${NEW_MAJOR}|g" {} +
+          find . -name 'README.md' -not -path './.git/*' -type f \
+            -exec sed -i "s|workos-go/v${CURRENT_MAJOR}|workos-go/v${NEW_MAJOR}|g" {} +
+
+          git config user.name "workos-sdk-automation[bot]"
+          git config user.email "255426317+workos-sdk-automation[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update go.mod and import paths for v${NEW_MAJOR}"
+            git push
+          fi
+
       # Inline pending changelog fragments under the version heading
       # release-please just wrote in CHANGELOG.md. For PRs that have a
       # fragment (the autogen flow always writes one), drop the line
@@ -128,40 +162,6 @@ jobs:
           git add CHANGELOG.md
           git commit -m "chore: inline release notes from .changelog-pending"
           git push
-
-      # Go modules require the module path and all import statements to
-      # include the major version (e.g. /v7). release-please doesn't handle
-      # this, so when a release PR bumps the major version we automatically
-      # rewrite go.mod, imports, and READMEs on the release PR branch.
-      - name: Migrate Go module path for major version bump
-        if: steps.release.outputs.pr
-        run: |
-          CURRENT_MAJOR=$(grep -oP 'module github\.com/workos/workos-go/v\K[0-9]+' go.mod)
-          NEW_VERSION=$(jq -r '."."' .release-please-manifest.json)
-          NEW_MAJOR="${NEW_VERSION%%.*}"
-
-          if [ "$CURRENT_MAJOR" = "$NEW_MAJOR" ]; then
-            echo "No major version change ($CURRENT_MAJOR → $NEW_MAJOR), skipping"
-            exit 0
-          fi
-
-          echo "Major version bump detected: v$CURRENT_MAJOR → v$NEW_MAJOR"
-
-          sed -i "s|module github.com/workos/workos-go/v${CURRENT_MAJOR}|module github.com/workos/workos-go/v${NEW_MAJOR}|" go.mod
-          find . -name '*.go' -not -path './.git/*' -type f \
-            -exec sed -i "s|github.com/workos/workos-go/v${CURRENT_MAJOR}|github.com/workos/workos-go/v${NEW_MAJOR}|g" {} +
-          find . -name 'README.md' -not -path './.git/*' -type f \
-            -exec sed -i "s|workos-go/v${CURRENT_MAJOR}|workos-go/v${NEW_MAJOR}|g" {} +
-
-          git config user.name "workos-sdk-automation[bot]"
-          git config user.email "255426317+workos-sdk-automation[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update go.mod and import paths for v${NEW_MAJOR}"
-            git push
-          fi
 
   # Detect when a release-please release PR has merged, then tag and
   # create the GitHub Release whose body is extracted from CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # WorkOS Go Library
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/workos/workos-go/v8.svg)](https://pkg.go.dev/github.com/workos/workos-go/v8)
+[![Go Reference](https://pkg.go.dev/badge/github.com/workos/workos-go/v9.svg)](https://pkg.go.dev/github.com/workos/workos-go/v9)
 
 The WorkOS Go library provides a flat, root-level `workos` package for applications written in Go.
 
@@ -11,7 +11,7 @@ The WorkOS Go library provides a flat, root-level `workos` package for applicati
 Requires Go `1.23+`.
 
 ```bash
-go get github.com/workos/workos-go/v8
+go get github.com/workos/workos-go/v9
 ```
 
 ## Usage
@@ -23,7 +23,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func main() {
@@ -210,5 +210,5 @@ This SDK is a Go library that uses a flat package layout at the module root rath
 Import the root package:
 
 ```go
-import "github.com/workos/workos-go/v8"
+import "github.com/workos/workos-go/v9"
 ```

--- a/actions_helper_test.go
+++ b/actions_helper_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 const testActionSecret = "action_secret_key"

--- a/admin_portal_test.go
+++ b/admin_portal_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestAdminPortal_GenerateLink(t *testing.T) {

--- a/api_keys_test.go
+++ b/api_keys_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestAPIKeys_ListOrganizationAPIKeys(t *testing.T) {

--- a/audit_logs_test.go
+++ b/audit_logs_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestAuditLogs_GetOrganizationAuditLogsRetention(t *testing.T) {

--- a/authkit_helpers_test.go
+++ b/authkit_helpers_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestGetAuthKitAuthorizationURL_BuildsCorrectURL(t *testing.T) {

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestAuthorization_Check(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestClient_UserAgentIncludesVersion(t *testing.T) {

--- a/connect_test.go
+++ b/connect_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestConnect_CompleteOAuth2(t *testing.T) {

--- a/directory_sync_test.go
+++ b/directory_sync_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestDirectorySync_List(t *testing.T) {

--- a/events_test.go
+++ b/events_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestEvents_List(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func ExampleNewClient() {

--- a/feature_flags_test.go
+++ b/feature_flags_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestFeatureFlags_List(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 // @oagen-ignore-file
 
-module github.com/workos/workos-go/v8
+module github.com/workos/workos-go/v9
 
 go 1.23
 

--- a/groups_test.go
+++ b/groups_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestGroups_ListOrganizationGroups(t *testing.T) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func ptrString(s string) *string { return &s }

--- a/jwks_helpers_test.go
+++ b/jwks_helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestGetJWKSURL_BuildsCorrectURL(t *testing.T) {

--- a/multi_factor_auth_test.go
+++ b/multi_factor_auth_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestMultiFactorAuth_VerifyChallenge(t *testing.T) {

--- a/organization_domains_test.go
+++ b/organization_domains_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestOrganizationDomains_Create(t *testing.T) {

--- a/organization_membership_test.go
+++ b/organization_membership_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestOrganizationMembership_List(t *testing.T) {

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestOrganizations_List(t *testing.T) {

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestIterator_MultiPage(t *testing.T) {

--- a/passwordless_test.go
+++ b/passwordless_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestPasswordless_CreateSession(t *testing.T) {

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestPipes_AuthorizeDataIntegration(t *testing.T) {

--- a/pkce_test.go
+++ b/pkce_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestGenerateCodeVerifier_DefaultLength(t *testing.T) {

--- a/public_client_test.go
+++ b/public_client_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestNewPublicClient_CreatesClient(t *testing.T) {

--- a/radar_test.go
+++ b/radar_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestRadar_CreateAttempt(t *testing.T) {

--- a/session_helpers_test.go
+++ b/session_helpers_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 const testCookiePassword = "test-cookie-password-for-session-helpers"

--- a/session_test.go
+++ b/session_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestSealData_UnsealData_RoundTrip(t *testing.T) {

--- a/sso_helpers_test.go
+++ b/sso_helpers_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestGetSSOAuthorizationURL_BuildsCorrectURL(t *testing.T) {

--- a/sso_test.go
+++ b/sso_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestSSO_ListConnections(t *testing.T) {

--- a/user_management_test.go
+++ b/user_management_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestUserManagement_GetJWKS(t *testing.T) {

--- a/vault_crypto_test.go
+++ b/vault_crypto_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func makeTestDataKeyPair() workos.CreateDataKeyResponse {

--- a/vault_test.go
+++ b/vault_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestVault_CreateDataKey(t *testing.T) {

--- a/webhook_verification_test.go
+++ b/webhook_verification_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 const testWebhookSecret = "whsec_test_secret_key"

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestWebhooks_ListEndpoints(t *testing.T) {

--- a/widgets_test.go
+++ b/widgets_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/workos/workos-go/v8"
+	"github.com/workos/workos-go/v9"
 )
 
 func TestWidgets_CreateToken(t *testing.T) {


### PR DESCRIPTION
This module bump did not occur because the release process had an error. In this PR, the module rename is being done ahead of some changelog work (in case the changelog process breaks, which is what happened last time). 

Closes https://github.com/workos/workos-go/issues/557