### PR TITLE
fix: Detect revoked refresh token via invalid_grant regardless of status

### DIFF
--- a/session_helpers.go
+++ b/session_helpers.go
@@ -185,9 +185,15 @@ func (s *Session) Refresh(ctx context.Context, opts ...RequestOption) (*RefreshS
 		OrganizationID: orgID,
 	}, opts...)
 	if err != nil {
+		// A terminal refresh failure surfaces as OAuth `invalid_grant` (the
+		// refresh token is expired, revoked, or reused past the grace window).
+		// The WorkOS token endpoint returns it at HTTP 400 — do not couple the
+		// check to a specific status. Any other error (429, 5xx, network, or a
+		// lock-timeout surfaced as 429) is transient: the refresh token is
+		// still valid, so keep the session and retry rather than signing out.
 		reason := "refresh_failed"
 		var apiErr *APIError
-		if errors.As(err, &apiErr) && apiErr.StatusCode == 401 && apiErr.ErrorCode == "invalid_grant" {
+		if errors.As(err, &apiErr) && apiErr.ErrorCode == "invalid_grant" {
 			reason = "refresh_token_revoked"
 		}
 		return &RefreshSessionResult{

--- a/session_helpers_test.go
+++ b/session_helpers_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -173,6 +175,52 @@ func TestNewSession_Authenticate_EmptySession(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, result.Authenticated)
 	require.Equal(t, "no_session_cookie_provided", result.Reason)
+}
+
+// A terminal refresh failure (OAuth invalid_grant) must be labeled
+// refresh_token_revoked. The WorkOS token endpoint returns invalid_grant at
+// HTTP 400, so detection must not be coupled to a 401 status.
+func TestSession_Refresh_InvalidGrantIsTerminal(t *testing.T) {
+	fakeJWT := buildFakeJWT()
+	sealed, err := workos.SealSessionFromAuthResponse(fakeJWT, "refresh_tok_abc", nil, nil, testCookiePassword)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/user_management/authenticate", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Refresh token is invalid."}`))
+	}))
+	defer server.Close()
+
+	client := workos.NewClient("sk_test", workos.WithBaseURL(server.URL))
+	result, err := client.RefreshSession(context.Background(), sealed, testCookiePassword)
+	require.Error(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.Authenticated)
+	require.Equal(t, "refresh_token_revoked", result.Reason)
+}
+
+// A non-invalid_grant failure (e.g. a generic 400) is not a dead token, so it
+// must remain the generic refresh_failed rather than being reported as revoked.
+func TestSession_Refresh_NonInvalidGrantIsNotRevoked(t *testing.T) {
+	fakeJWT := buildFakeJWT()
+	sealed, err := workos.SealSessionFromAuthResponse(fakeJWT, "refresh_tok_abc", nil, nil, testCookiePassword)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_request","error_description":"Something else."}`))
+	}))
+	defer server.Close()
+
+	client := workos.NewClient("sk_test", workos.WithBaseURL(server.URL))
+	result, err := client.RefreshSession(context.Background(), sealed, testCookiePassword)
+	require.Error(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.Authenticated)
+	require.Equal(t, "refresh_failed", result.Reason)
 }
 
 // GetLogoutURL must succeed for a session whose access token has expired:


### PR DESCRIPTION
## Description

`Session.Refresh()` only labeled a failure `refresh_token_revoked` when the API error was HTTP **401** + `invalid_grant`. But the sealed-session refresh endpoint (`POST /user_management/authenticate`, `grant_type=refresh_token`) returns terminal `invalid_grant` at HTTP **400** (per RFC 6749 §5.2). So a genuinely dead/revoked/expired refresh token was mislabeled as the generic transient `refresh_failed`, which can mislead callers into retrying a token that will never succeed.

Fix: key terminal detection off the OAuth error code, which is the authoritative terminal signal, rather than coupling it to a specific status:

```diff
-if errors.As(err, &apiErr) && apiErr.StatusCode == 401 && apiErr.ErrorCode == "invalid_grant" {
+if errors.As(err, &apiErr) && apiErr.ErrorCode == "invalid_grant" {
     reason = "refresh_token_revoked"
 }
```

Transient failures (429 / 5xx / network / lock-timeout surfaced as 429) still fall through to `refresh_failed`, and this helper never clears the session itself — the caller decides.

Only the hand-maintained `session_helpers.go` (`// @oagen-ignore-file`) is touched; no generated code changed.

Added regression tests in `session_helpers_test.go`:
- 400 `invalid_grant` → `refresh_token_revoked`
- 400 with a different error code → stays `refresh_failed`

Local: `go test ./...`, `go vet ./...`, `gofmt` all clean.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```


Link to Devin session: https://app.devin.ai/sessions/fc39103abf694f90b1c92dd714a81461
Requested by: @m0tzy