### PR TITLE
fix: use profile IDs for SSO logout

### DIFF
--- a/sso_helpers.go
+++ b/sso_helpers.go
@@ -164,10 +164,10 @@ type SSOLogoutParams struct {
 }
 
 // SSOLogout initiates a logout flow.
-// First obtains a logout token via AuthorizeLogout, then builds the logout redirect URL.
+// First obtains a logout URL via AuthorizeLogout, then appends return_to to it.
 func (c *Client) SSOLogout(ctx context.Context, params SSOLogoutParams, opts ...RequestOption) (string, error) {
 	if params.ProfileID != "" && params.SessionID != "" && params.ProfileID != params.SessionID {
-		return "", fmt.Errorf("workos: ProfileID and deprecated SessionID must match when both are provided")
+		return "", fmt.Errorf("workos: profile_id and deprecated session_id must match when both are provided")
 	}
 
 	profileID := params.ProfileID
@@ -175,10 +175,10 @@ func (c *Client) SSOLogout(ctx context.Context, params SSOLogoutParams, opts ...
 		profileID = params.SessionID
 	}
 	if profileID == "" {
-		return "", fmt.Errorf("workos: profile ID is required for SSO logout")
+		return "", fmt.Errorf("workos: profile_id is required for SSO logout")
 	}
 
-	// Step 1: Call AuthorizeLogout to get a logout token.
+	// Step 1: Call AuthorizeLogout to get the logout redirect URL.
 	logoutResp, err := c.SSO().AuthorizeLogout(ctx, &SSOAuthorizeLogoutParams{
 		ProfileID: profileID,
 	}, opts...)
@@ -186,23 +186,23 @@ func (c *Client) SSOLogout(ctx context.Context, params SSOLogoutParams, opts ...
 		return "", err
 	}
 
-	// Step 2: Build the logout redirect URL.
-	baseURL := c.baseURL
-	if baseURL == "" {
-		baseURL = defaultBaseURL
+	// Step 2: Use the logout URL returned by the API. Fall back to building it
+	// from the logout token if the response did not include one.
+	logoutURL := logoutResp.LogoutURL
+	if logoutURL == "" {
+		logoutURL = c.SSO().GetLogoutURL(&SSOGetLogoutURLParams{Token: logoutResp.LogoutToken}, opts...)
+	}
+	if params.ReturnTo == nil {
+		return logoutURL, nil
 	}
 
-	u, err := url.Parse(baseURL + "/sso/logout")
+	u, err := url.Parse(logoutURL)
 	if err != nil {
 		return "", fmt.Errorf("workos: failed to parse logout URL: %w", err)
 	}
 
 	q := u.Query()
-	q.Set("token", logoutResp.LogoutToken)
-	if params.ReturnTo != nil {
-		q.Set("return_to", *params.ReturnTo)
-	}
-
+	q.Set("return_to", *params.ReturnTo)
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }

--- a/sso_helpers.go
+++ b/sso_helpers.go
@@ -154,6 +154,11 @@ func (c *Client) SSOPKCECodeExchange(ctx context.Context, params SSOPKCECodeExch
 
 // SSOLogoutParams holds parameters for SSO logout.
 type SSOLogoutParams struct {
+	// ProfileID is the unique ID of the SSO profile to log out.
+	ProfileID string
+	// SessionID is retained for backward compatibility.
+	//
+	// Deprecated: Use ProfileID. Despite its name, this value must contain an SSO profile ID.
 	SessionID string
 	ReturnTo  *string
 }
@@ -161,9 +166,21 @@ type SSOLogoutParams struct {
 // SSOLogout initiates a logout flow.
 // First obtains a logout token via AuthorizeLogout, then builds the logout redirect URL.
 func (c *Client) SSOLogout(ctx context.Context, params SSOLogoutParams, opts ...RequestOption) (string, error) {
+	if params.ProfileID != "" && params.SessionID != "" && params.ProfileID != params.SessionID {
+		return "", fmt.Errorf("workos: ProfileID and deprecated SessionID must match when both are provided")
+	}
+
+	profileID := params.ProfileID
+	if profileID == "" {
+		profileID = params.SessionID
+	}
+	if profileID == "" {
+		return "", fmt.Errorf("workos: profile ID is required for SSO logout")
+	}
+
 	// Step 1: Call AuthorizeLogout to get a logout token.
 	logoutResp, err := c.SSO().AuthorizeLogout(ctx, &SSOAuthorizeLogoutParams{
-		ProfileID: params.SessionID,
+		ProfileID: profileID,
 	}, opts...)
 	if err != nil {
 		return "", err

--- a/sso_helpers_test.go
+++ b/sso_helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/workos/workos-go/v10"
 )
@@ -152,8 +153,8 @@ func TestGetSSOPKCEAuthorizationURL_PreservesCustomState(t *testing.T) {
 
 func TestSSOPKCECodeExchange_WithMockServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "POST", r.Method)
-		require.Equal(t, "/sso/token", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/sso/token", r.URL.Path)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -193,16 +194,16 @@ func TestSSOPKCECodeExchange_WithMockServer(t *testing.T) {
 
 func TestSSOLogout_WithProfileID(t *testing.T) {
 	// The SSOLogout helper first calls AuthorizeLogout (POST /sso/logout/authorize)
-	// to get a logout token, then builds the logout redirect URL.
+	// to get a logout URL, then appends return_to to it.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "POST", r.Method)
-		require.Equal(t, "/sso/logout/authorize", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/sso/logout/authorize", r.URL.Path)
 
 		var body struct {
 			ProfileID string `json:"profile_id"`
 		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		require.Equal(t, "prof_123", body.ProfileID)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "prof_123", body.ProfileID)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -246,7 +247,7 @@ func TestSSOLogout_RequiresProfileID(t *testing.T) {
 	client := workos.NewClient("sk_test", workos.WithBaseURL(server.URL))
 
 	_, err := client.SSOLogout(context.Background(), workos.SSOLogoutParams{})
-	require.EqualError(t, err, "workos: profile ID is required for SSO logout")
+	require.EqualError(t, err, "workos: profile_id is required for SSO logout")
 	require.Zero(t, requests.Load())
 }
 
@@ -265,7 +266,7 @@ func TestSSOLogout_RejectsConflictingProfileIDs(t *testing.T) {
 		ProfileID: "prof_new",
 		SessionID: "prof_legacy",
 	})
-	require.EqualError(t, err, "workos: ProfileID and deprecated SessionID must match when both are provided")
+	require.EqualError(t, err, "workos: profile_id and deprecated session_id must match when both are provided")
 	require.Zero(t, requests.Load())
 }
 
@@ -274,8 +275,8 @@ func TestSSOLogout_DeprecatedSessionIDFallback(t *testing.T) {
 		var body struct {
 			ProfileID string `json:"profile_id"`
 		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		require.Equal(t, "prof_legacy", body.ProfileID)
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "prof_legacy", body.ProfileID)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -302,4 +303,65 @@ func TestSSOLogout_DeprecatedSessionIDFallback(t *testing.T) {
 	q := parsed.Query()
 	require.Equal(t, "tok_abc", q.Get("token"))
 	require.Empty(t, q.Get("return_to"))
+}
+
+func TestSSOLogout_UsesReturnedLogoutURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"logout_url": "https://sso.example.com/sso/logout?token=tok_abc",
+			"logout_token": "tok_abc"
+		}`))
+	}))
+	defer server.Close()
+
+	client := workos.NewClient("sk_test", workos.WithBaseURL(server.URL))
+
+	returnTo := "https://example.com/signed-out"
+	logoutURL, err := client.SSOLogout(context.Background(), workos.SSOLogoutParams{
+		ProfileID: "prof_123",
+		ReturnTo:  &returnTo,
+	})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(logoutURL)
+	require.NoError(t, err)
+
+	require.Equal(t, "sso.example.com", parsed.Host)
+	require.Equal(t, "/sso/logout", parsed.Path)
+
+	q := parsed.Query()
+	require.Equal(t, "tok_abc", q.Get("token"))
+	require.Equal(t, "https://example.com/signed-out", q.Get("return_to"))
+}
+
+func TestSSOLogout_FallsBackToTokenWhenLogoutURLMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"logout_token": "tok_abc"}`))
+	}))
+	defer server.Close()
+
+	client := workos.NewClient("sk_test", workos.WithBaseURL(server.URL))
+
+	returnTo := "https://example.com/signed-out"
+	logoutURL, err := client.SSOLogout(context.Background(), workos.SSOLogoutParams{
+		ProfileID: "prof_123",
+		ReturnTo:  &returnTo,
+	})
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(logoutURL)
+	require.NoError(t, err)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	require.Equal(t, serverURL.Host, parsed.Host)
+	require.Equal(t, "/sso/logout", parsed.Path)
+
+	q := parsed.Query()
+	require.Equal(t, "tok_abc", q.Get("token"))
+	require.Equal(t, "https://example.com/signed-out", q.Get("return_to"))
 }

--- a/sso_helpers_test.go
+++ b/sso_helpers_test.go
@@ -4,9 +4,11 @@ package workos_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -189,12 +191,18 @@ func TestSSOPKCECodeExchange_WithMockServer(t *testing.T) {
 	require.Equal(t, "Bearer", result.TokenType)
 }
 
-func TestSSOLogout_WithMockServer(t *testing.T) {
+func TestSSOLogout_WithProfileID(t *testing.T) {
 	// The SSOLogout helper first calls AuthorizeLogout (POST /sso/logout/authorize)
 	// to get a logout token, then builds the logout redirect URL.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "POST", r.Method)
 		require.Equal(t, "/sso/logout/authorize", r.URL.Path)
+
+		var body struct {
+			ProfileID string `json:"profile_id"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "prof_123", body.ProfileID)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -212,7 +220,7 @@ func TestSSOLogout_WithMockServer(t *testing.T) {
 
 	returnTo := "https://example.com/signed-out"
 	logoutURL, err := client.SSOLogout(context.Background(), workos.SSOLogoutParams{
-		SessionID: "sess_123",
+		ProfileID: "prof_123",
 		ReturnTo:  &returnTo,
 	})
 	require.NoError(t, err)
@@ -226,8 +234,49 @@ func TestSSOLogout_WithMockServer(t *testing.T) {
 	require.Equal(t, "https://example.com/signed-out", q.Get("return_to"))
 }
 
-func TestSSOLogout_WithoutReturnTo(t *testing.T) {
+func TestSSOLogout_RequiresProfileID(t *testing.T) {
+	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"logout_token":"tok_abc"}`))
+	}))
+	defer server.Close()
+
+	client := workos.NewClient("sk_test", workos.WithBaseURL(server.URL))
+
+	_, err := client.SSOLogout(context.Background(), workos.SSOLogoutParams{})
+	require.EqualError(t, err, "workos: profile ID is required for SSO logout")
+	require.Zero(t, requests.Load())
+}
+
+func TestSSOLogout_RejectsConflictingProfileIDs(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"logout_token":"tok_abc"}`))
+	}))
+	defer server.Close()
+
+	client := workos.NewClient("sk_test", workos.WithBaseURL(server.URL))
+
+	_, err := client.SSOLogout(context.Background(), workos.SSOLogoutParams{
+		ProfileID: "prof_new",
+		SessionID: "prof_legacy",
+	})
+	require.EqualError(t, err, "workos: ProfileID and deprecated SessionID must match when both are provided")
+	require.Zero(t, requests.Load())
+}
+
+func TestSSOLogout_DeprecatedSessionIDFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			ProfileID string `json:"profile_id"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "prof_legacy", body.ProfileID)
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{
@@ -243,7 +292,7 @@ func TestSSOLogout_WithoutReturnTo(t *testing.T) {
 	)
 
 	logoutURL, err := client.SSOLogout(context.Background(), workos.SSOLogoutParams{
-		SessionID: "sess_123",
+		SessionID: "prof_legacy",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description
The SSO logout endpoint requires a profile ID. The helper incorrectly asked callers for a session ID.

Add ProfileID and send it to the logout authorization endpoint. Keep SessionID as a deprecated fallback for existing callers. Return an error when the caller supplies no ID or supplies conflicting IDs.

Update the tests to check the request body and the compatibility behavior.
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

Closes #605 
